### PR TITLE
VAO support and `string` updates

### DIFF
--- a/vgl_array.hpp
+++ b/vgl_array.hpp
@@ -12,17 +12,18 @@ namespace vgl
 template<typename T, unsigned N> class array
 {
 public:
-    /// Convenience typedef.
+    /// Value type.
     using value_type = T;
-
     /// Iterator type.
-    using iterator = T*;
+    using iterator = value_type*;
     /// Const iterator type.
-    using const_iterator = const T*;
+    using const_iterator = const value_type*;
+    /// Type of this class.
+    using this_type = array<value_type, N>;
 
 public:
     /// Array data.
-    T m_data[N];
+    value_type m_data[N];
 
 private:
     /// Boundary check.
@@ -62,17 +63,10 @@ public:
     {
         return m_data;
     }
-    /// Iterator to the beginning.
+    /// Const iterator to the beginning.
     ///
     /// \return Iterator.
     constexpr const_iterator begin() const noexcept
-    {
-        return m_data;
-    }
-    /// Iterator to the beginning.
-    ///
-    /// \return Iterator.
-    constexpr const_iterator cbegin() const noexcept
     {
         return m_data;
     }
@@ -84,17 +78,10 @@ public:
     {
         return m_data + N;
     }
-    /// Iterator to the end.
+    /// Const iterator to the end.
     ///
-    /// \return Iterator.
+    /// \return Const iterator.
     constexpr const_iterator end() const noexcept
-    {
-        return m_data + N;
-    }
-    /// Iterator to the end.
-    ///
-    /// \return Iterator.
-    constexpr const_iterator cend() const noexcept
     {
         return m_data + N;
     }
@@ -193,6 +180,9 @@ public:
         accessCheck(idx);
         return m_data[idx];
     }
+
+public:
+    VGL_ITERATOR_FUNCTIONS(this_type)
 };
 
 }

--- a/vgl_array.hpp
+++ b/vgl_array.hpp
@@ -1,6 +1,8 @@
 #ifndef VGL_ARRAY_HPP
 #define VGL_ARRAY_HPP
 
+#include "vgl_config.hpp"
+
 #if defined(USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif

--- a/vgl_assert.hpp
+++ b/vgl_assert.hpp
@@ -1,7 +1,9 @@
 #ifndef VGL_ASSERT_HPP
 #define VGL_ASSERT_HPP
 
-#if defined(USE_LD) && defined(DEBUG)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD) && defined(DEBUG)
 #include <boost/assert.hpp>
 /// Assertion macro (enabled).
 #define VGL_ASSERT(expr) BOOST_ASSERT(expr)

--- a/vgl_buffer.cpp
+++ b/vgl_buffer.cpp
@@ -6,7 +6,7 @@ namespace vgl
 namespace detail
 {
 
-OpenGlBufferState OpenGlBufferState::g_opengl_buffer_state;
+OpenGlVertexArrayObjectState OpenGlVertexArrayObjectState::g_opengl_vertex_array_object_state;
 
 }
 

--- a/vgl_config.hpp
+++ b/vgl_config.hpp
@@ -1,0 +1,18 @@
+#ifndef VGL_CONFIG_HPP
+#define VGL_CONFIG_HPP
+
+/// \file Configuration macro parsing.
+///
+/// This top-level header should be the first in inclusion chain from all other headers.
+
+#if defined(USE_LD) && USE_LD
+/// Compile expecting a linker will be used.
+#define VGL_USE_LD
+#endif
+
+#if defined(DNLOAD_GLESV2) && DNLOAD_GLESV2
+/// Use OpenGL ES as opposed to OpenGL.
+#define VGL_USE_GLES
+#endif
+
+#endif

--- a/vgl_config.hpp
+++ b/vgl_config.hpp
@@ -15,4 +15,45 @@
 #define VGL_USE_GLES
 #endif
 
+/// Declarator for functions that allow returning iterators.
+///
+/// Must be inserted into class public scope.
+/// Includes both friend functions and cbegin()/cend() wrappers.
+/// Class itself must only declare begin() and end().
+///
+/// \param Type Type to declare for.
+#define VGL_ITERATOR_FUNCTIONS(Type) \
+constexpr const_iterator cbegin() const noexcept \
+{ \
+    return begin(); \
+} \
+friend constexpr iterator begin(Type& op) noexcept \
+{ \
+    return op.begin(); \
+} \
+friend constexpr const_iterator begin(const Type& op) noexcept \
+{ \
+    return op.begin(); \
+} \
+friend constexpr const_iterator cbegin(const Type& op) noexcept \
+{ \
+    return op.begin(); \
+} \
+constexpr const_iterator cend() const noexcept \
+{ \
+    return end(); \
+} \
+friend constexpr iterator end(Type& op) noexcept \
+{ \
+    return op.end(); \
+} \
+friend constexpr const_iterator end(const Type& op) noexcept \
+{ \
+    return op.end(); \
+} \
+friend constexpr const_iterator cend(const Type& op) noexcept \
+{ \
+    return op.end(); \
+}
+
 #endif

--- a/vgl_extern_opengl.hpp
+++ b/vgl_extern_opengl.hpp
@@ -1,10 +1,11 @@
 #ifndef VGL_EXTERN_OPENGL_HPP
 #define VGL_EXTERN_OPENGL_HPP
 
-/// \file
-/// \brief External include: OpenGL
+/// \file External include: OpenGL
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #if defined(_WIN32) || defined(_WIN64)
 #define _USE_MATH_DEFINES
@@ -12,7 +13,11 @@
 #include "windows.h"
 #endif
 
-#if defined(VGL_ENABLE_GTK)
+#if defined(VGL_USE_GLES)
+#define GL_GLEXT_PROTOTYPES
+#include "GLES3/gl3.h"
+#include "GLES2/gl2ext.h"
+#elif defined(VGL_ENABLE_GTK)
 #define GL_GLEXT_PROTOTYPES
 #include "GL/gl.h"
 #include "GL/glext.h"
@@ -38,6 +43,9 @@
 #endif
 #if !defined(dnload_glBindTexture)
 #define dnload_glBindTexture glBindTexture
+#endif
+#if !defined(dnload_glBindVertexArray)
+#define dnload_glBindVertexArray glBindVertexArray
 #endif
 #if !defined(dnload_glBlendFuncSeparate)
 #define dnload_glBlendFuncSeparate glBlendFuncSeparate
@@ -128,6 +136,9 @@
 #endif
 #if !defined(dnload_glGenTextures)
 #define dnload_glGenTextures glGenTextures
+#endif
+#if !defined(dnload_glGenVertexArrays)
+#define dnload_glGenVertexArrays glGenVertexArrays
 #endif
 #if !defined(dnload_glGetAttribLocation)
 #define dnload_glGetAttribLocation glGetAttribLocation

--- a/vgl_extern_stdlib.hpp
+++ b/vgl_extern_stdlib.hpp
@@ -1,8 +1,9 @@
 #ifndef VGL_EXTERN_STDLIB_HPP
 #define VGL_EXTERN_STDLIB_HPP
 
-/// \file
-/// \brief External include: stdlib
+/// \file External include: stdlib
+
+#include "vgl_config.hpp"
 
 #include <cstdlib>
 

--- a/vgl_geometry_handle.hpp
+++ b/vgl_geometry_handle.hpp
@@ -15,7 +15,7 @@ namespace detail
 {
 
 /// \cond
-void geometry_buffer_bind(const GeometryBuffer& geometry_buffer, const GlslProgram& prog);
+void geometry_buffer_bind(GeometryBuffer& geometry_buffer, const GlslProgram& prog);
 /// \endcond
 
 }

--- a/vgl_glsl_program.cpp
+++ b/vgl_glsl_program.cpp
@@ -3,7 +3,6 @@
 namespace vgl
 {
 
-const GeometryBuffer* GlslProgram::g_current_geometry_buffer = nullptr;
 const GlslProgram* GlslProgram::g_current_program = nullptr;
 
 #if defined(USE_LD)

--- a/vgl_glsl_program.hpp
+++ b/vgl_glsl_program.hpp
@@ -270,9 +270,6 @@ private:
     GLuint m_id = 0;
 
 public:
-    /// Currently bound geometry buffer.
-    static const GeometryBuffer* g_current_geometry_buffer;
-
     /// Currently active program.
     static const GlslProgram* g_current_program;
 
@@ -510,9 +507,6 @@ public:
         {
             dnload_glUseProgram(m_id);
             g_current_program = this;
-
-            // Must also clear current geometry buffer.
-            g_current_geometry_buffer = nullptr;
         }
     }
 

--- a/vgl_limits.hpp
+++ b/vgl_limits.hpp
@@ -1,6 +1,8 @@
 #ifndef VGL_LIMITS_HPP
 #define VGL_LIMITS_HPP
 
+#include "vgl_config.hpp"
+
 #include <limits>
 
 namespace vgl

--- a/vgl_realloc.hpp
+++ b/vgl_realloc.hpp
@@ -10,7 +10,7 @@
 
 #include "vgl_extern_stdlib.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include <stdexcept>
 #include <boost/throw_exception.hpp>
 #endif

--- a/vgl_state.cpp
+++ b/vgl_state.cpp
@@ -9,7 +9,6 @@ namespace vgl
 namespace detail
 {
 
-OpenGlAttribState OpenGlAttribState::g_opengl_attrib_state;
 OpenGlBlendState OpenGlBlendState::g_opengl_blend_state;
 OpenGlClearState OpenGlClearState::g_opengl_clear_state;
 OpenGlColorWriteState OpenGlColorWriteState::g_opengl_color_write_state;

--- a/vgl_state.hpp
+++ b/vgl_state.hpp
@@ -44,65 +44,6 @@ string to_string(OperationMode op);
 namespace detail
 {
 
-/// OpenGL attribute array state abstraction.
-class OpenGlAttribState
-{
-public:
-    /// Maximum number of attribute arrays.
-    static const unsigned MAX_ATTRIB_ARRAYS = 6u;
-
-private:
-    /// Attribute array enabled statuses.
-    bool m_attrib_arrays_enabled[MAX_ATTRIB_ARRAYS] =
-    {
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-    };
-
-public:
-    /// Global state.
-    static OpenGlAttribState g_opengl_attrib_state;
-
-public:
-    /// Enable one vertex attribute.
-    ///
-    /// \param op Index of array to enable.
-    void enableAttribArray(unsigned op)
-    {
-#if defined(USE_LD)
-        if((MAX_ATTRIB_ARRAYS <= op))
-        {
-            VGL_THROW_RUNTIME_ERROR("enabling attribute index " + to_string(op) + " (" +
-                    to_string(MAX_ATTRIB_ARRAYS) + " supported)");
-        }
-#endif
-        if(!m_attrib_arrays_enabled[op])
-        {
-            dnload_glEnableVertexAttribArray(op);
-            m_attrib_arrays_enabled[op] = true;
-        }
-    }
-
-    /// Disable extra vertex attribute arrays.
-    ///
-    /// \param op Index of first array to disable.
-    void disableAttribArraysFrom(unsigned op)
-    {
-        for(unsigned ii = op; (ii < MAX_ATTRIB_ARRAYS); ++ii)
-        {
-            if(m_attrib_arrays_enabled[ii])
-            {
-                dnload_glDisableVertexAttribArray(ii);
-                m_attrib_arrays_enabled[ii] = false;
-            }
-        }
-    }
-};
-
 /// OpenGL blend state abstraction.
 class OpenGlBlendState
 {
@@ -577,22 +518,6 @@ public:
 
 #endif
 
-}
-
-/// Enable one vertex attribute.
-///
-/// \param op Index of array to enable.
-inline void attrib_array_enable(unsigned op)
-{
-    detail::OpenGlAttribState::g_opengl_attrib_state.enableAttribArray(op);
-}
-
-/// Disable extra vertex attribute arrays.
-///
-/// \param op Index of first array to disable.
-inline void attrib_array_disable_from(unsigned op)
-{
-    detail::OpenGlAttribState::g_opengl_attrib_state.disableAttribArraysFrom(op);
 }
 
 /// Set blending mode.

--- a/vgl_string.hpp
+++ b/vgl_string.hpp
@@ -581,6 +581,35 @@ public:
     }
 
 #if defined(USE_LD)
+    /// Erase a part of the string.
+    ///
+    /// \param start_iter Starting iterator to erase from.
+    /// \param end_iter Ending iterator to erase to.
+    iterator erase(const_iterator start_iter, const_iterator end_iter)
+    {
+        unsigned new_length = length() - static_cast<unsigned>(end_iter - start_iter);
+        value_type* new_data = array_new(static_cast<value_type*>(nullptr), new_length + 1);
+        value_type* insertion_iter = new_data;
+
+        for(const_iterator ii = cbegin(); (ii < start_iter); ++ii)
+        {
+            *insertion_iter = *ii;
+            ++insertion_iter;
+        }
+        iterator ret = insertion_iter;
+        for(const_iterator ii = end_iter, ee = cend(); (ii < ee); ++ii)
+        {
+            *insertion_iter = *ii;
+            ++insertion_iter;
+        }
+        *insertion_iter = static_cast<value_type>(0);
+
+        array_delete(base_type::m_data);
+        base_type::m_data = new_data;
+        base_type::m_length = new_length;
+        return ret;
+    }
+
     /// Insert into the string.
     ///
     /// \param pos Insertion position.

--- a/vgl_string.hpp
+++ b/vgl_string.hpp
@@ -37,9 +37,11 @@ public:
     /// Value type.
     using value_type = T;
     /// Iterator type.
-    using iterator = T*;
+    using iterator = value_type*;
     /// Const iterator type.
-    using const_iterator = const T*;
+    using const_iterator = const value_type*;
+    /// Type of this class.
+    using this_type = string_data<value_type>;
 
 public:
     /// No-position.
@@ -47,7 +49,7 @@ public:
 
 protected:
     /// Internal data.
-    T* m_data = nullptr;
+    value_type* m_data = nullptr;
 
     /// String length.
     unsigned m_length = 0;
@@ -60,7 +62,7 @@ protected:
     ///
     /// \param data Data input.
     /// \param length Length.
-    constexpr explicit string_data(T* data, unsigned length) noexcept :
+    constexpr explicit string_data(value_type* data, unsigned length) noexcept :
         m_data(data),
         m_length(length)
     {
@@ -103,14 +105,14 @@ public:
     /// Iterator to the beginning.
     ///
     /// \return Iterator.
-    constexpr iterator begin() const noexcept
+    constexpr iterator begin() noexcept
     {
         return m_data;
     }
-    /// Iterator to the beginning.
+    /// Const iterator to the beginning.
     ///
-    /// \return Iterator.
-    constexpr const_iterator cbegin() const noexcept
+    /// \return Const iterator.
+    constexpr const_iterator begin() const noexcept
     {
         return m_data;
     }
@@ -118,14 +120,14 @@ public:
     /// Iterator to the end.
     ///
     /// \return Iterator.
-    constexpr iterator end() const noexcept
+    constexpr iterator end() noexcept
     {
         return m_data + m_length;
     }
-    /// Iterator to the end.
+    /// Const iterator to the end.
     ///
-    /// \return Iterator.
-    constexpr const_iterator cend() const noexcept
+    /// \return Const iterator.
+    constexpr const_iterator end() const noexcept
     {
         return m_data + m_length;
     }
@@ -149,7 +151,7 @@ public:
     /// Returns the internal data pointer.
     ///
     /// \return Data pointer.
-    constexpr const T* data() const noexcept
+    constexpr const value_type* data() const noexcept
     {
         if(m_data)
         {
@@ -164,7 +166,7 @@ public:
     /// \param rhs Right-hand side operand.
     /// \param pos Position to start search from.
     /// \return Found index or npos if not found.
-    constexpr unsigned find(const string_data& rhs, unsigned pos = 0) const noexcept
+    constexpr unsigned find(const this_type& rhs, unsigned pos = 0) const noexcept
     {
         if(rhs.length() > m_length)
         {
@@ -185,7 +187,7 @@ public:
     ///
     /// \param op Substring to test.
     /// \return True if starts with given substring, false otherwise.
-    constexpr bool starts_with(const T* op)
+    constexpr bool starts_with(const value_type* op)
     {
         for(unsigned ii = 0;;)
         {
@@ -215,7 +217,7 @@ private:
     /// \param rhs Right-hand side operand.
     /// \param pos Position to search from.
     /// \return True if found, false if not.
-    constexpr bool matchAtPosition(const string_data& rhs, unsigned pos) const noexcept
+    constexpr bool matchAtPosition(const this_type& rhs, unsigned pos) const noexcept
     {
         for(unsigned ii = 0; (ii < rhs.length()); ++ii)
         {
@@ -232,7 +234,7 @@ public:
     /// Access operator.
     ///
     /// \return Element reference.
-    constexpr T& operator[](unsigned idx)
+    constexpr value_type& operator[](unsigned idx)
     {
         accessCheck(idx);
         return m_data[idx];
@@ -240,7 +242,7 @@ public:
     /// Const access operator.
     ///
     /// \return Element reference.
-    constexpr const T& operator[](unsigned idx) const
+    constexpr const value_type& operator[](unsigned idx) const
     {
         accessCheck(idx);
         return m_data[idx];
@@ -248,7 +250,7 @@ public:
     /// Access operator.
     ///
     /// \return Element reference.
-    constexpr T& operator[](int idx)
+    constexpr value_type& operator[](int idx)
     {
         accessCheck(idx);
         return m_data[idx];
@@ -256,7 +258,7 @@ public:
     /// Const access operator.
     ///
     /// \return Element reference.
-    constexpr const T& operator[](int idx) const
+    constexpr const value_type& operator[](int idx) const
     {
         accessCheck(idx);
         return m_data[idx];
@@ -339,7 +341,7 @@ public:
     /// \param lhs Left-hand-side operand.
     /// \param rhs Right-hand-side operand.
     /// \return Output stream.
-    friend std::ostream& operator<<(std::ostream& lhs, const string_data<T>& rhs)
+    friend std::ostream& operator<<(std::ostream& lhs, const this_type& rhs)
     {
         for(const T& cc : rhs)
         {
@@ -348,6 +350,9 @@ public:
         return lhs;
     }
 #endif
+
+public:
+    VGL_ITERATOR_FUNCTIONS(this_type)
 };
 
 }
@@ -524,7 +529,7 @@ public:
     ///
     /// \param op Input data.
     /// \return This object.
-    string& assign(const string_data<value_type>& op)
+    string& assign(const base_type::this_type& op)
     {
         return assign(const_cast<const char*>(op.data()), op.length());
     }

--- a/vgl_string.hpp
+++ b/vgl_string.hpp
@@ -587,6 +587,11 @@ public:
     /// \param end_iter Ending iterator to erase to.
     iterator erase(const_iterator start_iter, const_iterator end_iter)
     {
+        VGL_ASSERT(start_iter >= begin());
+        VGL_ASSERT(start_iter <= end());
+        VGL_ASSERT(end_iter >= begin());
+        VGL_ASSERT(end_iter <= end());
+        VGL_ASSERT(end_iter >= start_iter);
         unsigned new_length = length() - static_cast<unsigned>(end_iter - start_iter);
         value_type* new_data = array_new(static_cast<value_type*>(nullptr), new_length + 1);
         value_type* insertion_iter = new_data;
@@ -617,6 +622,9 @@ public:
     /// \param end_iter End iterator to insert.
     template<class IteratorType> void insert(const_iterator pos, IteratorType start_iter, IteratorType end_iter)
     {
+        VGL_ASSERT(pos >= begin());
+        VGL_ASSERT(pos <= end());
+        VGL_ASSERT(end_iter >= start_iter);
         unsigned new_length = length() + static_cast<unsigned>(end_iter - start_iter);
         value_type* new_data = array_new(static_cast<value_type*>(nullptr), new_length + 1);
         value_type* insertion_iter = new_data;

--- a/vgl_vector.hpp
+++ b/vgl_vector.hpp
@@ -188,14 +188,14 @@ public:
     /// Iterator to the beginning.
     ///
     /// \return Iterator.
-    constexpr iterator begin() const noexcept
+    constexpr iterator begin() noexcept
     {
         return m_data;
     }
-    /// Iterator to the beginning.
+    /// Const iterator to the beginning.
     ///
-    /// \return Iterator.
-    constexpr const_iterator cbegin() const noexcept
+    /// \return Const iterator.
+    constexpr const_iterator begin() const noexcept
     {
         return m_data;
     }
@@ -203,14 +203,14 @@ public:
     /// Iterator to the end.
     ///
     /// \return Iterator.
-    constexpr iterator end() const noexcept
+    constexpr iterator end() noexcept
     {
         return m_data + m_size;
     }
-    /// Iterator to the end.
+    /// Const iterator to the end.
     ///
-    /// \return Iterator.
-    constexpr const_iterator cend() const noexcept
+    /// \return Const iterator.
+    constexpr const_iterator end() const noexcept
     {
         return m_data + m_size;
     }
@@ -473,6 +473,9 @@ public:
     {
         return (0 < m_size);
     }
+
+public:
+    VGL_ITERATOR_FUNCTIONS(vector<T>)
 };
 
 }

--- a/vgl_vertex_array_object.hpp
+++ b/vgl_vertex_array_object.hpp
@@ -1,0 +1,114 @@
+#ifndef VGL_VERTEX_ARRAY_OBJECT
+#define VGL_VERTEX_ARRAY_OBJECT
+
+#include "vgl_buffer.hpp"
+
+namespace vgl
+{
+
+/// \cond
+class GlslProgram;
+class MeshData;
+class VertexArrayObject;
+/// \endcond
+
+namespace detail
+{
+
+/// \cond
+void setup_vertex_array_object(
+        const VertexArrayObject& vertex_array_object,
+        const GlslProgram& program,
+        const VertexBuffer& vertex_buffer,
+        const IndexBuffer& index_buffer,
+        const MeshData& data);
+/// \endcond
+
+}
+
+/// Abstraction for vertex array object.
+class VertexArrayObject
+{
+private:
+    /// Vertex array object id.
+    GLuint m_id = 0;
+
+private:
+    /// Deleted copy constructor.
+    VertexArrayObject(const VertexArrayObject&) = delete;
+    /// Deleted assignment.
+    VertexArrayObject& operator=(const VertexArrayObject&) = delete;
+
+public:
+    /// Default constructor.
+    ///
+    /// \param program Program associated with the vertex array object.
+    /// \param vertex_buffer Vertex buffer to use.
+    /// \param index_buffer Index buffer to use.
+    /// \param data Data to use for format.
+    explicit VertexArrayObject(
+            const GlslProgram& program,
+            const VertexBuffer& vertex_buffer,
+            const IndexBuffer& index_buffer,
+            const MeshData& data)
+    {
+        dnload_glGenVertexArrays(1, &m_id);
+        detail::setup_vertex_array_object(*this, program, vertex_buffer, index_buffer, data);
+    }
+
+    /// Destructor.
+    ~VertexArrayObject()
+    {
+#if defined(USE_LD)
+        if(m_id)
+        {
+            detail::OpenGlVertexArrayObjectState::g_opengl_vertex_array_object_state.invalidate(m_id);
+            glDeleteVertexArrays(1, &m_id);
+        }
+#endif
+    }
+
+    /// Move constructor.
+    ///
+    /// \param other Source object.
+    VertexArrayObject(VertexArrayObject&& other) :
+        m_id(other.m_id)
+    {
+#if defined(USE_LD)
+        other.m_id = 0;
+#endif
+    }
+
+public:
+    /// Accessor.
+    ///
+    /// \return Identifier.
+    GLuint getId() const
+    {
+        return m_id;
+    }
+
+    /// Binds the vertex array object for use.
+    void bind() const
+    {
+        detail::OpenGlVertexArrayObjectState::g_opengl_vertex_array_object_state.bind(m_id);
+    }
+
+public:
+    /// Move operator.
+    ///
+    /// \param other Source object.
+    /// \return This object.
+    VertexArrayObject& operator=(VertexArrayObject&& other)
+    {
+        m_id = other.m_id;
+#if defined(USE_LD)
+        other.m_id = 0;
+#endif
+        return *this;
+    }
+};
+
+}
+
+#endif

--- a/vgl_wave.cpp
+++ b/vgl_wave.cpp
@@ -91,10 +91,10 @@ string glsl_tidy(string_view source)
 /// \param bb String iterator.
 /// \param ee String endpoint.
 /// \return Iterator to end of match or original iterator if no match.
-static std::string::const_iterator regex_line_comment(std::string::const_iterator bb,
-        const std::string::const_iterator &ee)
+string::const_iterator regex_line_comment(string::const_iterator bb,
+        const string::const_iterator &ee)
 {
-    std::string::const_iterator ii = bb;
+    string::const_iterator ii = bb;
 
     if((ii == ee) || ('/' != *ii))
     {
@@ -126,10 +126,10 @@ static std::string::const_iterator regex_line_comment(std::string::const_iterato
 /// \param bb String iterator.
 /// \param ee String endpoint.
 /// \return Iterator to end of match or original iterator if no match.
-static std::string::const_iterator regex_block_comment(std::string::const_iterator bb,
-        const std::string::const_iterator &ee)
+string::const_iterator regex_block_comment(string::const_iterator bb,
+        const string::const_iterator &ee)
 {
-    std::string::const_iterator ii = bb;
+    string::const_iterator ii = bb;
     bool allow_return = false;
 
     if((ii == ee) || ('/' != *ii))
@@ -170,10 +170,10 @@ static std::string::const_iterator regex_block_comment(std::string::const_iterat
 /// \param bb String iterator.
 /// \param ee String endpoint.
 /// \return Iterator to end of match or original iterator if no match.
-static std::string::const_iterator regex_comment(std::string::const_iterator bb,
-        const std::string::const_iterator &ee)
+string::const_iterator regex_comment(string::const_iterator bb,
+        const string::const_iterator &ee)
 {
-    std::string::const_iterator ii = regex_line_comment(bb, ee);
+    string::const_iterator ii = regex_line_comment(bb, ee);
     if(ii != bb)
     {
         return ii;
@@ -186,10 +186,10 @@ static std::string::const_iterator regex_comment(std::string::const_iterator bb,
 /// \param bb String iterator.
 /// \param ee String endpoint.
 /// \return Iterator at the end of whitespace.
-static std::string::const_iterator regex_whitespace(std::string::const_iterator bb,
-        const std::string::const_iterator ee)
+string::const_iterator regex_whitespace(string::const_iterator bb,
+        const string::const_iterator ee)
 {
-    for(std::string::const_iterator ii = bb; (ii != ee); ++ii)
+    for(string::const_iterator ii = bb; (ii != ee); ++ii)
     {
         if(!isspace(static_cast<int>(*ii)))
         {
@@ -205,10 +205,10 @@ static std::string::const_iterator regex_whitespace(std::string::const_iterator 
 /// \param ee String endpoint.
 /// \param word Word to match.
 /// \return Iterator to end of match or original iterator if no match.
-static std::string::const_iterator regex_word_whitespace(std::string::const_iterator bb,
-        const std::string::const_iterator ee, std::string_view word)
+string::const_iterator regex_word_whitespace(string::const_iterator bb,
+        const string::const_iterator ee, string_view word)
 {
-    std::string::const_iterator ii = bb;
+    string::const_iterator ii = bb;
     unsigned jj = 0;
 
     while(word.length() > jj)
@@ -234,10 +234,10 @@ static std::string::const_iterator regex_word_whitespace(std::string::const_iter
 /// \param bb String iterator.
 /// \param ee String endpoint.
 /// \return Iterator to end of match or original iterator if no match.
-static std::string::const_iterator regex_precision_whitespace(std::string::const_iterator bb,
-        const std::string::const_iterator ee)
+string::const_iterator regex_precision_whitespace(string::const_iterator bb,
+        const string::const_iterator ee)
 {
-    std::string::const_iterator ii = regex_word_whitespace(bb, ee, "lowp");
+    string::const_iterator ii = regex_word_whitespace(bb, ee, "lowp");
     if(ii != bb)
     {
         return regex_whitespace(ii, ee);
@@ -261,16 +261,16 @@ static std::string::const_iterator regex_precision_whitespace(std::string::const
 /// \param bb String iterator.
 /// \param ee String endpoint.
 /// \return Iterator to end of match or original iterator if no match.
-static std::string::const_iterator regex_glesv2(std::string::const_iterator bb,
-        const std::string::const_iterator ee)
+string::const_iterator regex_glesv2(string::const_iterator bb,
+        const string::const_iterator ee)
 {
-    std::string::const_iterator ii = bb;
+    string::const_iterator ii = bb;
 
     // Try "precision" statement."
-    std::string::const_iterator jj = regex_word_whitespace(ii, ee, "precision");
+    string::const_iterator jj = regex_word_whitespace(ii, ee, "precision");
     if(jj != ii)
     {
-        std::string::const_iterator kk = jj;
+        string::const_iterator kk = jj;
         jj = regex_precision_whitespace(kk, ee);
         if(jj != kk)
         {
@@ -298,15 +298,15 @@ static std::string::const_iterator regex_glesv2(std::string::const_iterator bb,
     return bb;
 }
 
-std::string convert_glesv2_gl(std::string_view op)
+string convert_glesv2_gl(string_view op)
 {
-    std::string ret(op);
-    std::string::const_iterator ii = cbegin(ret);
-    std::string::const_iterator ee = cend(ret);
+    string ret(op);
+    string::const_iterator ii = cbegin(ret);
+    string::const_iterator ee = cend(ret);
 
     while(ii != ee)
     {
-        std::string::const_iterator jj = regex_glesv2(ii, ee);
+        string::const_iterator jj = regex_glesv2(ii, ee);
         if(jj != ii)
         {
             ii = ret.erase(ii, jj);

--- a/vgl_wave.cpp
+++ b/vgl_wave.cpp
@@ -8,12 +8,12 @@
 #include <boost/wave/cpp_context.hpp>
 #include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
 
+namespace vgl
+{
+
 using wave_token = boost::wave::cpplexer::lex_token<>;
 using wave_cpplex_iterator = boost::wave::cpplexer::lex_iterator<wave_token>;
 using wave_context = boost::wave::context<std::string::const_iterator, wave_cpplex_iterator>;
-
-namespace vgl
-{
 
 namespace
 {
@@ -22,18 +22,18 @@ namespace
 ///
 /// \param source Source input.
 /// \return Pair of strings, GLSL shader compiler preprocessor input and rest of the source.
-std::pair<std::string, std::string> glsl_split(std::string_view source)
+std::pair<string, string> glsl_split(string_view source)
 {
-    vector<std::string> lines;
+    vector<string> lines;
 
     boost::split(lines, source, boost::is_any_of("\n"));
 
-    std::vector<std::string> glsl_list;
-    std::vector<std::string> cpp_list;
+    vector<string> glsl_list;
+    vector<string> cpp_list;
 
     for(const auto& vv : lines)
     {
-        std::string ii = boost::trim_copy(vv);
+        string ii = boost::trim_copy(vv);
 
         if(boost::starts_with(ii, "#"))
         {
@@ -50,8 +50,8 @@ std::pair<std::string, std::string> glsl_split(std::string_view source)
         cpp_list.push_back(vv);
     }
 
-    std::string glsl_ret = boost::algorithm::join(glsl_list, "\n");
-    std::string cpp_ret = boost::algorithm::join(cpp_list, "\n");
+    string glsl_ret = boost::algorithm::join(glsl_list, "\n");
+    string cpp_ret = boost::algorithm::join(cpp_list, "\n");
 
     if(!glsl_ret.empty())
     {
@@ -333,7 +333,7 @@ std::string convert_glesv2_gl(std::string_view op)
 
 string wave_preprocess_glsl(string_view op)
 {
-    std::string input_source = read_file_locate(op).c_str();
+    string input_source = read_file_locate(op).c_str();
 
 #if !defined(DNLOAD_GLESV2)
     input_source = convert_glesv2_gl(input_source);

--- a/vgl_wave.cpp
+++ b/vgl_wave.cpp
@@ -2,8 +2,6 @@
 
 #include "vgl_filesystem.hpp"
 
-//#include <utility>
-
 #include <boost/algorithm/string.hpp>
 #include <boost/wave/cpp_context.hpp>
 #include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
@@ -13,7 +11,7 @@ namespace vgl
 
 using wave_token = boost::wave::cpplexer::lex_token<>;
 using wave_cpplex_iterator = boost::wave::cpplexer::lex_iterator<wave_token>;
-using wave_context = boost::wave::context<std::string::const_iterator, wave_cpplex_iterator>;
+using wave_context = boost::wave::context<string::const_iterator, wave_cpplex_iterator>;
 
 namespace
 {
@@ -65,17 +63,17 @@ std::pair<string, string> glsl_split(string_view source)
 ///
 /// \prarm source Source input.
 /// \return Source with preprocessor lines removed.
-std::string glsl_tidy(std::string_view source)
+string glsl_tidy(string_view source)
 {
-    std::vector<std::string> lines;
+    vector<string> lines;
 
     boost::split(lines, source, boost::is_any_of("\n"));
 
-    std::vector<std::string> accepted;
+    vector<string> accepted;
 
     for(const auto& vv : lines)
     {
-        std::string ii = boost::trim_copy(vv);
+        string ii = boost::trim_copy(vv);
 
         if(!boost::starts_with(ii, "#"))
         {
@@ -340,7 +338,7 @@ string wave_preprocess_glsl(string_view op)
 #endif
 
     // Split into GLSL preprocess code and the rest.
-    std::pair<std::string, std::string> source = glsl_split(input_source);
+    std::pair<string, string> source = glsl_split(input_source);
 
     // Preprocess with wave.
     std::ostringstream preprocessed;
@@ -351,7 +349,7 @@ string wave_preprocess_glsl(string_view op)
         preprocessed << vv.get_value();
     }
 
-    return source.first + glsl_tidy(preprocessed.str());
+    return source.first + glsl_tidy(string_view(preprocessed.str().c_str()));
 }
 
 }


### PR DESCRIPTION
Import VAO supprort from another working branch.
Improve `string` to allow most operations possible on `std::string`, testbench is `vgl_wave.cpp`.
Macro for friend iterator functions for vgl container types.