### PR TITLE
Fix performance errors for platforms that choke on unaligned vertex buffer data

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 New BSD licence: http://opensource.org/licenses/BSD-3-Clause
 
-Copyright (c) 2015-2020, Faemiyah
+Copyright (c) 2015-2025, Faemiyah
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/test.cpp
+++ b/test.cpp
@@ -12,7 +12,7 @@ using vgl::vector;
 ///
 /// To understand the significance of USE_LD and dnload(), see:
 /// http://faemiyah.fi/demoscene/dnload
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 int main(int argc, char** argv)
 #else
 void _start()
@@ -54,7 +54,7 @@ void _start()
     }
     dnload_putchar('\n');
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     (void)argc;
     (void)argv;
     return 0;

--- a/vgl_animation.hpp
+++ b/vgl_animation.hpp
@@ -48,7 +48,7 @@ private:
     {
         unsigned frame_amount = bone_amount * 7;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(animation_data_size % (frame_amount + 1) != 0)
         {
             VGL_THROW_RUNTIME_ERROR("incompatible bone (" + to_string(bone_amount) + ") and animation (" +
@@ -66,14 +66,14 @@ public:
     /// Accessor.
     ///
     /// \param idx Index.
-    AnimationFrame& getFrame(unsigned idx)
+    constexpr AnimationFrame& getFrame(unsigned idx)
     {
         return m_frames[idx];
     }
     /// Const accessor.
     ///
     /// \param idx Index.
-    const AnimationFrame& getFrame(unsigned idx) const
+    constexpr const AnimationFrame& getFrame(unsigned idx) const
     {
         return m_frames[idx];
     }
@@ -81,7 +81,7 @@ public:
     /// Accessor.
     ///
     /// \return Bone count.
-    unsigned getBoneCount() const
+    constexpr unsigned getBoneCount() const
     {
         return m_frames.empty() ? 0 : m_frames[0].getBoneCount();
     }
@@ -89,7 +89,7 @@ public:
     /// Accessor.
     ///
     /// \return Frame count.
-    unsigned getFrameCount() const
+    constexpr unsigned getFrameCount() const
     {
         return m_frames.size();
     }
@@ -97,14 +97,14 @@ public:
     /// Tell if this animation is hierarchical.
     ///
     /// \return True if yes, false if no.
-    bool isHierarchical() const
+    constexpr bool isHierarchical() const
     {
         return m_hierarchical;
     }
     /// Set hierarchical status of this animation.
     ///
     /// \param op New hierarchical status.
-    void setHierarchical(bool op)
+    constexpr void setHierarchical(bool op)
     {
         m_hierarchical = op;
     }
@@ -124,8 +124,8 @@ public:
         return unique_ptr<Animation>(new Animation(data, bone_amount, animation_data_size, scale, hierarchical));
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Output to stream.
     ///
     /// \param ostr Output stream.

--- a/vgl_animation_frame.hpp
+++ b/vgl_animation_frame.hpp
@@ -12,14 +12,14 @@ class AnimationFrame
 {
 private:
     /// Timestamp.
-    float m_time;
+    float m_time = 0.0f;
 
     /// Bone data.
     vector<BoneState> m_bones;
 
 public:
     /// Empty constructor.
-    explicit AnimationFrame() noexcept = default;
+    constexpr explicit AnimationFrame() noexcept = default;
 
     /// Constructor.
     ///
@@ -41,7 +41,7 @@ private:
     {
         m_time = fixed_8_8_to_float(data[0]);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if((frame_amount % 7) != 0)
         {
             VGL_THROW_RUNTIME_ERROR("invalid frame amount: " + to_string(frame_amount));
@@ -119,7 +119,7 @@ public:
     void interpolateFrom(const AnimationFrame &lhs, const AnimationFrame &rhs, float current_time)
     {
         unsigned bone_count = lhs.getBoneCount();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(rhs.getBoneCount() != bone_count)
         {
             VGL_THROW_RUNTIME_ERROR("cannot interpolate between frames of size " + to_string(bone_count) + " and " +
@@ -142,8 +142,8 @@ public:
         }
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Output to stream.
     ///
     /// \param ostr Output stream.

--- a/vgl_animation_state.hpp
+++ b/vgl_animation_state.hpp
@@ -19,7 +19,7 @@ private:
 
 public:
     /// Empty constructor.
-    explicit AnimationState() noexcept = default;
+    constexpr explicit AnimationState() noexcept = default;
 
     /// Initializing constructor.
     ///
@@ -43,7 +43,7 @@ public:
     /// Accessor.
     ///
     /// \return Matrix data.
-    const mat4* getBoneData() const
+    constexpr const mat4* getBoneData() const
     {
         return m_matrices.data();
     }
@@ -51,12 +51,12 @@ public:
     /// Accessor.
     ///
     /// \return Matrix count.
-    unsigned getBoneCount() const
+    constexpr unsigned getBoneCount() const
     {
         return m_matrices.size();
     }
 
-    /// Create identiry frame.
+    /// Create identity frame.
     ///
     /// \param op Number of identity matrices.
     void identityFrame(unsigned op)
@@ -67,7 +67,7 @@ public:
             m_matrices[ii] = mat4::identity();
         }
     }
-    /// Create identiry frame.
+    /// Create identity frame.
     ///
     /// \param op Animation to extract number of identity matrices from.
     void identityFrame(const Animation& op)
@@ -84,7 +84,7 @@ public:
     void interpolateFrom(const Animation &anim, float current_time)
     {
         unsigned frame_count = anim.getFrameCount();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(0 >= frame_count)
         {
             VGL_THROW_RUNTIME_ERROR("can't animate animation without frames");
@@ -107,7 +107,7 @@ public:
                 const AnimationFrame &rr = anim.getFrame(ii);
                 float rtime = rr.getTime();
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
                 if(ll.getTime() >= rtime)
                 {
                     VGL_THROW_RUNTIME_ERROR("animation index " + to_string(ii) + " has time " +
@@ -123,7 +123,7 @@ public:
                 }
 
                 ++ii;
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
                 if(ii >= frame_count)
                 {
                     VGL_THROW_RUNTIME_ERROR("could not find frames to interpolate for time " +

--- a/vgl_armature.hpp
+++ b/vgl_armature.hpp
@@ -49,7 +49,7 @@ private:
             unsigned hierarchy_amount,
             float scale)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!m_bones.empty())
         {
             VGL_THROW_RUNTIME_ERROR("trying to init non-empty armature from data");
@@ -77,7 +77,7 @@ private:
                 }
             }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(hdata + hierarchy_amount != iter)
             {
                 VGL_THROW_RUNTIME_ERROR("reference data inconsistency: " +
@@ -158,8 +158,8 @@ public:
         return unique_ptr<Armature>(new Armature(bdata, hdata, bones_amount, hierarchy_amount, scale));
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Output to stream.
     ///
     /// \param ostr Output stream.

--- a/vgl_array.hpp
+++ b/vgl_array.hpp
@@ -3,7 +3,7 @@
 
 #include "vgl_config.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif
 
@@ -33,7 +33,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(unsigned idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx >= N)
         {
             VGL_THROW_RUNTIME_ERROR("accessing index " + to_string(idx) + " from array of size " + to_string(N));
@@ -47,7 +47,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(int idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx < 0)
         {
             VGL_THROW_RUNTIME_ERROR("accessing negative index " + to_string(idx) + " from array of size " +

--- a/vgl_bitset.hpp
+++ b/vgl_bitset.hpp
@@ -66,8 +66,8 @@ public:
             return m_ref.getInternal(m_index);
         }
 
+#if defined(VGL_USE_LD)
     public:
-#if defined(USE_LD)
         /// Stream output operator.
         ///
         /// \param lhs Left-hand-side operand.
@@ -110,7 +110,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(unsigned idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx >= N)
         {
             VGL_THROW_RUNTIME_ERROR("accessing bit index " + to_string(idx) + " from " + to_string(N) + "-bit set");
@@ -124,7 +124,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(int idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx < 0)
         {
             VGL_THROW_RUNTIME_ERROR("accessing negative bit index " + to_string(idx) + " from " + to_string(N) +
@@ -137,7 +137,7 @@ private:
     /// Assert that the data only has bits in the valid range.
     constexpr void assertData() const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(m_data & (!mask()))
         {
             VGL_THROW_RUNTIME_ERROR("bitset value " + to_string(m_data) + " has bits outside " + to_string(N) +

--- a/vgl_bone.hpp
+++ b/vgl_bone.hpp
@@ -40,7 +40,7 @@ private:
     /// \param op New parent.
     void setParent(Bone* op)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_parent)
         {
             VGL_THROW_RUNTIME_ERROR("bone " + to_string(this) + " already has parent: " + to_string(m_parent));

--- a/vgl_bone_state.hpp
+++ b/vgl_bone_state.hpp
@@ -104,8 +104,8 @@ public:
 #endif
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Output to stream.
     ///
     /// \param ostr Output stream.

--- a/vgl_bounding_box.hpp
+++ b/vgl_bounding_box.hpp
@@ -200,8 +200,8 @@ public:
         return *this;
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_buffer.hpp
+++ b/vgl_buffer.hpp
@@ -34,7 +34,7 @@ public:
         }
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Invalidates given vertex array object.
     ///
     /// \param op Vertex array object ID.
@@ -83,7 +83,7 @@ public:
     /// Destructor.
     ~Buffer()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         glDeleteBuffers(1, &m_id);
 #endif
     }
@@ -172,7 +172,7 @@ using IndexBuffer = Buffer<GL_ELEMENT_ARRAY_BUFFER>;
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_buffer.cpp"
 #endif
 

--- a/vgl_cond.hpp
+++ b/vgl_cond.hpp
@@ -40,7 +40,7 @@ public:
     {
 #if defined(VGL_ENABLE_GTK)
         dnload_g_cond_init(m_cond);
-#elif defined(USE_LD) && defined(DEBUG)
+#elif defined(VGL_USE_LD) && defined(DEBUG)
         if(!m_cond)
         {
             VGL_THROW_RUNTIME_ERROR(string("Cond::Cond(): ") + SDL_GetError());
@@ -72,7 +72,7 @@ public:
     }
 
 public:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Accessor.
     ///
     /// \return Internal implementation.
@@ -89,7 +89,7 @@ public:
         dnload_g_cond_broadcast(m_cond);
 #else
         int err = dnload_SDL_CondBroadcast(m_cond);
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR(string("Cond::broadcast(): ") + SDL_GetError());
@@ -107,7 +107,7 @@ public:
         dnload_g_cond_broadcast(m_cond);
 #else
         int err = dnload_SDL_CondSignal(m_cond);
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR(string("Cond::signal(): ") + SDL_GetError());
@@ -158,7 +158,7 @@ private:
         dnload_g_cond_wait(m_cond, mutex);
 #else
         int err = dnload_SDL_CondWait(m_cond, mutex);
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR(string("internal_cond_wait(): ") + SDL_GetError());
@@ -182,8 +182,8 @@ public:
         return *this;
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_config.hpp
+++ b/vgl_config.hpp
@@ -48,8 +48,8 @@
 ///
 /// - VGL_ENABLE_VERTEX_NORMAL_PACKING
 ///
-///   Pack vertex normals into normalized integers. Increases code footprint but may also increase performance due to
-///   reduced memory usage. Performance may be decreased due to vertex attribute misalignment on some platforms.
+///   Pack vertex normals into normalized short integers. Increases code footprint but may increase performance due to
+///   reduced memory usage. May also decrease performance due to vertex attribute misalignment on some platforms.
 ///
 /// - VGL_USE_BONE_STATE_FULL_TRANSFORM
 ///

--- a/vgl_config.hpp
+++ b/vgl_config.hpp
@@ -3,7 +3,64 @@
 
 /// \file Configuration macro parsing.
 ///
-/// This top-level header should be the first in inclusion chain from all other headers.
+/// This top-level header should be the first in inclusion chain from all other headers. All configuration macros
+/// should be declared before including vgl headers (that will eventually include this file). To avoid surprising
+/// errors when using multiple source files, preferably declare the macros using the build system.
+///
+/// All options are default off. The following options are recognized:
+///
+/// - VGL_DISABLE_CEIL
+///
+///   Disable ceil() function in math. May decreases code footprint.
+///
+/// - VGL_DISABLE_DEPTH_WRITE
+///
+///   Disable ability to toggle depth write. Decreases code footprint.
+///
+/// - VGL_DISABLE_DEPTH_TEXTURE
+///
+///   Disable support for depth textures. Increases code footprint, but may increase performance by using
+///   renderbuffers as opposed to textures for all FBO depth buffers. Use on platforms with limited support for depth
+///   texture formats.
+///
+/// - VGL_DISABLE_EDGE
+///
+///   Disable support for edge buffers (and by extension, stencil shadows) in meshes. Decreases code footprint.
+///
+///   TODO: This feature is currently unsupported.
+///
+/// - VGL_DISABLE_OGG
+///
+///   Disable support for ogg containers for opus playback. Decreases code footprint, but requires custom opus data
+///   generated using the opus2raw binary.
+///
+/// - VGL_DISABLE_OPUS
+///
+///   Disable support for opus. Decreases code footprint.
+///
+/// - VGL_DISABLE_STENCIL
+///
+///   Disable support for stencil buffer. Decreases code footprint.
+///
+/// - VGL_ENABLE_GTK
+///
+///   Enable support for GTK, mainly for implementing concurrency primitives. If not set, SDL is used instead.
+///
+/// - VGL_ENABLE_VERTEX_NORMAL_PACKING
+///
+///   Pack vertex normals into normalized integers. Increases code footprint but may also increase performance due to
+///   reduced memory usage. Performance may be decreased due to vertex attribute misalignment on some platforms.
+///
+/// - VGL_USE_BONE_STATE_FULL_TRANSFORM
+///
+///   Interpolate complete transformation matrices and renormalize them after interpolation as opposed to
+///   interpolating quaternions. Increases code footprint.
+///
+///   TODO: Should not be required but something in the bone animation is buggy.
+///
+/// - VGL_USE_LD
+///
+///   Compile assuming a real linker is in use. Should be enabled whenever not doing minified builds.
 
 #if defined(USE_LD) && USE_LD
 /// Compile expecting a linker will be used.
@@ -13,6 +70,11 @@
 #if defined(DNLOAD_GLESV2) && DNLOAD_GLESV2
 /// Use OpenGL ES as opposed to OpenGL.
 #define VGL_USE_GLES
+#endif
+
+#if !defined(VGL_DISABLE_EDGE)
+/// Edge buffers are not currently supported.
+#define VGL_DISABLE_EDGE
 #endif
 
 /// Declarator for functions that allow returning iterators.

--- a/vgl_csg_file.hpp
+++ b/vgl_csg_file.hpp
@@ -1,7 +1,9 @@
 #ifndef VGL_CSG_FILE
 #define VGL_CSG_FILE
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "vgl_filesystem.hpp"
 

--- a/vgl_cstddef.hpp
+++ b/vgl_cstddef.hpp
@@ -1,6 +1,8 @@
 #ifndef VGL_CSTDDEF_HPP
 #define VGL_CSTDDEF_HPP
 
+#include "vgl_config.hpp"
+
 #include <cstddef>
 
 namespace vgl
@@ -10,7 +12,7 @@ using std::nullptr_t;
 
 }
 
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
 #define VGL_VOLUNTARY_MEMBER_VALUE(name, value) name = value
 #else
 #define VGL_VOLUNTARY_MEMBER_VALUE(name, value) name

--- a/vgl_extern_freetype.hpp
+++ b/vgl_extern_freetype.hpp
@@ -1,10 +1,12 @@
-#ifndef VGL_EXTERN_FREEETYPE_HPP
-#define VGL_EXTERN_FREEETYPE_HPP
+#ifndef VGL_EXTERN_FREETYPE_HPP
+#define VGL_EXTERN_FREETYPE_HPP
 
 /// \file
 /// \brief External include: Freetype
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "ft2build.h"
 #include FT_FREETYPE_H

--- a/vgl_extern_gtk.hpp
+++ b/vgl_extern_gtk.hpp
@@ -4,7 +4,9 @@
 /// \file
 /// \brief External include: GTK
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "gtk/gtk.h"
 

--- a/vgl_extern_math.hpp
+++ b/vgl_extern_math.hpp
@@ -4,9 +4,11 @@
 /// \file
 /// \brief External include: math
 
+#include "vgl_config.hpp"
+
 #include <cmath>
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// \cond
 #if !defined(dnload_ceilf)

--- a/vgl_extern_sdl.hpp
+++ b/vgl_extern_sdl.hpp
@@ -4,7 +4,9 @@
 /// \file
 /// \brief External include: SDL
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "SDL.h"
 

--- a/vgl_extern_stdlib.hpp
+++ b/vgl_extern_stdlib.hpp
@@ -7,7 +7,7 @@
 
 #include <cstdlib>
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// \cond
 #if !defined(dnload_free)

--- a/vgl_fence.hpp
+++ b/vgl_fence.hpp
@@ -6,7 +6,7 @@
 #include "vgl_scoped_acquire.hpp"
 #include "vgl_unique_ptr.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #include <iostream>
 #endif
@@ -49,7 +49,7 @@ public:
     explicit FenceData() = default;
 
 public:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Accessor.
     ///
     /// \return Internal implementation.
@@ -104,7 +104,7 @@ public:
     }
 
 public:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.
@@ -165,7 +165,7 @@ public:
     /// \return Return value from the function.
     void* getReturnValue()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!m_fence_data)
         {
             VGL_THROW_RUNTIME_ERROR("fence data has already been cleared");
@@ -210,7 +210,7 @@ private:
         if(m_fence_data)
         {
             void* ret = detail::internal_fence_wait(*this);
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
             if(ret)
             {
                 std::cerr << "Fence::destruct(): unhandled return value '" << ret << "'" << std::endl;
@@ -244,8 +244,8 @@ public:
         return m_fence_data->isActive();
     }
 
-#if defined(USE_LD)
 
+#if defined(VGL_USE_LD)
 public:
     /// Stream output operator.
     ///
@@ -256,7 +256,6 @@ public:
     {
         return lhs << "Fence(" << rhs.m_fence_data->getCondImpl() << ")";
     }
-
 #endif
 };
 

--- a/vgl_fence_pool.hpp
+++ b/vgl_fence_pool.hpp
@@ -24,7 +24,7 @@ public:
     /// Destructor.
     ~FencePool()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         while(!m_pool.empty())
         {
             FenceData* data = m_pool.front();

--- a/vgl_filesystem.hpp
+++ b/vgl_filesystem.hpp
@@ -1,10 +1,12 @@
 #ifndef VGL_EXTERN_BOOST_FILESYSTEM_HPP
 #define VGL_EXTERN_BOOST_FILESYSTEM_HPP
 
-/// \file boost::filesystem locating and reading functionality.
+/// \file Filesystem locating and reading functionality.
 /// This file only makes sense when not building size-minimized. It's not header-only.
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "vgl_optional.hpp"
 #include "vgl_string_view.hpp"

--- a/vgl_font.cpp
+++ b/vgl_font.cpp
@@ -5,7 +5,7 @@ namespace vgl
 
 FT_Library Font::g_freetype_library = nullptr;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 unsigned Font::g_freetype_count = 0;
 #endif
 

--- a/vgl_font.hpp
+++ b/vgl_font.hpp
@@ -3,7 +3,7 @@
 
 #include "vgl_character.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_filesystem.hpp"
 #endif
 
@@ -17,7 +17,7 @@ private:
     /// FreeType library reference.
     static FT_Library g_freetype_library;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Number of fonts initialized.
     static unsigned g_freetype_count;
 #endif
@@ -50,7 +50,7 @@ public:
 
         for(const char **iter = fnames; true; ++iter)
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(!(*iter))
             {
                 std::ostringstream sstr;
@@ -69,7 +69,7 @@ public:
         }
 
         FT_Error err = dnload_FT_Set_Pixel_Sizes(m_face, 0, m_font_size);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR("could not set font size to " + to_string(m_font_size) + " on " +
@@ -83,7 +83,7 @@ public:
     /// Destructor.
     ~Font()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_face)
         {
             FT_Done_Face(m_face);
@@ -102,7 +102,7 @@ private:
     bool load(const char* fname)
     {
         FT_Error err;
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         path pth = find_file(fname);
         if(pth.empty())
         {
@@ -122,7 +122,7 @@ public:
     void createCharacter(unsigned unicode)
     {
         unsigned idx = dnload_FT_Get_Char_Index(m_face, unicode);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(0 >= idx)
         {
             VGL_THROW_RUNTIME_ERROR("no character " + to_string(unicode)+ " found in font");
@@ -130,7 +130,7 @@ public:
 #endif
 
         FT_Error err = dnload_FT_Load_Glyph(m_face, idx, FT_LOAD_DEFAULT);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR("error loading character " + to_string(unicode) + " at index " + to_string(idx) +
@@ -144,7 +144,7 @@ public:
         if(glyph->format != FT_GLYPH_FORMAT_BITMAP)
         {
             err = dnload_FT_Render_Glyph(glyph, FT_RENDER_MODE_NORMAL);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(err)
             {
                 VGL_THROW_RUNTIME_ERROR("error rendering glyph " + to_string(unicode) + " at index " +
@@ -174,7 +174,7 @@ public:
     /// \return Reference to the character.
     const Character& getCharacter(unsigned unicode) const
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_characters.size() <= unicode)
         {
             VGL_THROW_RUNTIME_ERROR("unicode index outside of range: " + to_string(unicode));
@@ -198,7 +198,7 @@ public:
         FT_Vector delta;
 
         FT_Error err = dnload_FT_Get_Kerning(m_face, prev, next, FT_KERNING_DEFAULT, &delta);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR("could not get kerning information for " + to_string(prev) + " and " +
@@ -218,7 +218,7 @@ private:
     /// If this is the first call, initialize FreeType.
     static void freetype_increment()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         VGL_ASSERT(static_cast<bool>(g_freetype_count) == static_cast<bool>(g_freetype_library));
         ++g_freetype_count;
 #endif
@@ -228,7 +228,7 @@ private:
         }
 
         FT_Error err = dnload_FT_Init_FreeType(&g_freetype_library);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(0 != err)
         {
             VGL_THROW_RUNTIME_ERROR("could not init FreeType: " + to_string(err));
@@ -249,7 +249,7 @@ public:
         return unique_ptr<Font>(new Font(fs, fnames));
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Decrement FreeType usage count.
     ///
     /// Deinitialize FreeType if the usage count reaches zero.
@@ -280,7 +280,7 @@ using FontUptr = unique_ptr<Font>;
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_font.cpp"
 #endif
 

--- a/vgl_frame_buffer.hpp
+++ b/vgl_frame_buffer.hpp
@@ -62,7 +62,7 @@ public:
         m_width(width),
         m_height(height)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if((m_width <= 0) || (m_height <= 0))
         {
             VGL_THROW_RUNTIME_ERROR("invalid framebuffer dimensions: " + to_string(width) + "x" + to_string(height));
@@ -93,7 +93,7 @@ public:
 #endif
         }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
         if(status != GL_FRAMEBUFFER_COMPLETE)
         {
@@ -110,7 +110,7 @@ public:
     /// Destructor.
     ~FrameBuffer()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_id)
         {
             glDeleteFramebuffers(1, &m_id);
@@ -267,7 +267,7 @@ public:
     }
 
 public:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Output to stream.
     ///
     /// \param lhs Left-hand-side operand.
@@ -289,7 +289,7 @@ using FrameBufferUptr = unique_ptr<FrameBuffer>;
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_frame_buffer.cpp"
 #endif
 

--- a/vgl_geometry_buffer.hpp
+++ b/vgl_geometry_buffer.hpp
@@ -108,7 +108,7 @@ public:
         m_data(op)
     {
         update();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         detail::increment_buffer_data_sizes(op);
 #endif
     }
@@ -122,7 +122,7 @@ private:
         GeometryHandle ret(*this, m_data.getVertexOffset(), m_data.getIndexOffset());
         m_data.append(op);
         update();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         detail::increment_buffer_data_sizes(op);
 #endif
         return ret;
@@ -178,8 +178,8 @@ public:
         m_vao_mapping.emplace_back(op, m_vertex_buffer, m_index_buffer, m_data);
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_geometry_channel.cpp
+++ b/vgl_geometry_channel.cpp
@@ -3,7 +3,7 @@
 namespace vgl
 {
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Get human-readable string corresponding to a channel
 ///

--- a/vgl_geometry_channel.hpp
+++ b/vgl_geometry_channel.hpp
@@ -3,7 +3,7 @@
 
 #include "vgl_extern_opengl.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif
 
@@ -35,7 +35,7 @@ enum GeometryChannel
     COUNT = 6,
 };
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Get human-readable string corresponding to a channel
 ///
@@ -66,12 +66,12 @@ constexpr GLint geometry_channel_element_count(GeometryChannel op)
     case COLOR:
     case BONE_WEIGHT:
     case BONE_REF:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
     default:
 #endif
         return 4;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     default:
         VGL_THROW_RUNTIME_ERROR("no element count defined for channel " + to_string(static_cast<int>(op)));
 #endif
@@ -87,23 +87,28 @@ constexpr GLenum geometry_channel_element_type(GeometryChannel op)
     switch(op)
     {
     case POSITION:
+#if !defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
+    case NORMAL:
+#endif
     case TEXCOORD:
         return GL_FLOAT;
 
+#if defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
     case NORMAL:
         return GL_SHORT;
+#endif
 
     case COLOR:
     case BONE_WEIGHT:
     case BONE_REF:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
     default:
 #endif
         return GL_UNSIGNED_BYTE;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     default:
-        VGL_THROW_RUNTIME_ERROR("no element count defined for channel " + to_string(static_cast<int>(op)));
+        VGL_THROW_RUNTIME_ERROR("no element type defined for channel " + to_string(static_cast<int>(op)));
 #endif
     }
 }
@@ -117,19 +122,24 @@ constexpr GLboolean geometry_channel_element_normalized(GeometryChannel op)
     switch(op)
     {
     case POSITION:
+#if !defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
+    case NORMAL:
+#endif
     case TEXCOORD:
     case BONE_REF:
         return GL_FALSE;
 
+#if defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
     case NORMAL:
+#endif
     case COLOR:
     case BONE_WEIGHT:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
     default:
 #endif
         return GL_TRUE;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     default:
         VGL_THROW_RUNTIME_ERROR("no element normalized status defined for channel " +
                 to_string(static_cast<int>(op)));

--- a/vgl_geometry_handle.hpp
+++ b/vgl_geometry_handle.hpp
@@ -85,8 +85,8 @@ public:
                 reinterpret_cast<void*>(m_index_offset));
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_glsl_program.cpp
+++ b/vgl_glsl_program.cpp
@@ -5,7 +5,7 @@ namespace vgl
 
 const GlslProgram* GlslProgram::g_current_program = nullptr;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 string to_string(UniformSemantic op)
 {

--- a/vgl_glsl_program.hpp
+++ b/vgl_glsl_program.hpp
@@ -74,7 +74,7 @@ enum class UniformSemantic
     SKELETON,
 };
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Get human-readable string corresponding to a channel
 ///
@@ -125,7 +125,7 @@ public:
         return m_location;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Is this location entry valid?
     ///
     /// \return True if location >= 0, false otherwise.
@@ -173,7 +173,7 @@ public:
         return m_channel;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Refresh name
     ///
     /// \param op Program ID to refresh for.
@@ -221,7 +221,7 @@ public:
         return m_semantic;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Refresh name
     ///
     /// \param op Program ID to refresh for.
@@ -232,7 +232,7 @@ public:
 #endif
 };
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Get program info log.
 ///
@@ -353,7 +353,7 @@ private:
         {
             return m_vert;
         }
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(type != GL_FRAGMENT_SHADER)
         {
             VGL_THROW_RUNTIME_ERROR("invalid shader type: " + to_string(type));
@@ -370,7 +370,7 @@ private:
         dnload_glAttachShader(id, vert);
         dnload_glAttachShader(id, frag);
         dnload_glLinkProgram(id);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!detail::get_program_link_status(id))
         {
             std::cout << detail::get_program_info_log(id);
@@ -381,7 +381,7 @@ private:
         return id;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Refresh attribute and uniform locations.
     void refreshLocations()
     {
@@ -412,7 +412,7 @@ public:
     /// \param name Name of the attribute.
     void addAttribute(GeometryChannel channel, const char* name)
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         for(const auto& vv : m_attributes)
         {
             if(vv.getChannel() == channel)
@@ -423,7 +423,7 @@ public:
         }
 #endif
         m_attributes.emplace_back(m_id, channel, name);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!m_attributes.back().isValid())
         {
             VGL_THROW_RUNTIME_ERROR("cannot add attribute '" + string(name) + "' to program " + to_string(m_id));
@@ -451,7 +451,7 @@ public:
     void addUniform(UniformSemantic semantic, const char* name)
     {
         m_uniforms.emplace_back(m_id, semantic, name);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!m_attributes.back().isValid())
         {
             VGL_THROW_RUNTIME_ERROR("cannot add uniform '" + string(name) + "' with semantic " + to_string(semantic) +
@@ -480,7 +480,7 @@ public:
                 return vv.getLocation();
             }
         }
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         std::cerr << "WARNING: program " << m_id << " has no uniform " << op << std::endl;
 #endif
         return -1;
@@ -538,7 +538,7 @@ public:
         linkCheck();
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Re-link the program.
     bool relink()
     {
@@ -563,7 +563,7 @@ public:
     template<typename...Args> void uniform(string_view name, Args&&... args)
     {
         GLint location = getUniformLocation(name);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(location >= 0)
 #endif
         {
@@ -761,7 +761,7 @@ public:
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_glsl_program.cpp"
 #endif
 

--- a/vgl_glsl_shader.cpp
+++ b/vgl_glsl_shader.cpp
@@ -6,7 +6,7 @@ namespace vgl
 namespace detail
 {
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 string get_shader_info_log(GLuint op)
 {

--- a/vgl_glsl_shader.hpp
+++ b/vgl_glsl_shader.hpp
@@ -4,7 +4,7 @@
 #include "vgl_extern_opengl.hpp"
 #include "vgl_string_view.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_vector.hpp"
 #include "vgl_wave.hpp"
 #include <iostream>
@@ -16,7 +16,7 @@ namespace vgl
 namespace detail
 {
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Get shader info log.
 ///
@@ -38,7 +38,7 @@ bool get_shader_compile_status(GLuint op);
 class GlslShader
 {
 private:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Vector containing all source files.
     vector<string> m_files;
 #endif
@@ -84,7 +84,7 @@ public:
     ///
     /// \param op Source shader.
     constexpr GlslShader(GlslShader&& op) noexcept :
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_files(move(op.m_files)),
 #endif
         m_type(op.m_type),
@@ -111,7 +111,7 @@ private:
         GLuint id = dnload_glCreateShader(type);
         dnload_glShaderSource(id, static_cast<GLsizei>(count), sources, NULL);
         dnload_glCompileShader(id);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         static const char* shader_delim = "----\n";
         if(!detail::get_shader_compile_status(id))
         {
@@ -143,7 +143,7 @@ private:
     /// \return Compiled source.
     GLuint compile(string_view op)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_files.clear();
         m_files.emplace_back(op);
         return compile(m_files);
@@ -163,7 +163,7 @@ private:
     /// \return Compiled source.
     GLuint compile(string_view op1, string_view op2)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_files.clear();
         m_files.emplace_back(op1);
         m_files.emplace_back(op2);
@@ -177,7 +177,7 @@ private:
 #endif
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Compile from a source file vector.
     ///
     /// \param source_files Source files.
@@ -207,7 +207,7 @@ public:
         return m_id;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Recompile from existing source files.
     ///
     /// \return Compiled source.
@@ -226,7 +226,7 @@ public:
     /// \return This object.
     constexpr GlslShader& operator=(GlslShader&& op) noexcept
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_files = move(op.m_files);
 #endif
         m_type = op.m_type;

--- a/vgl_image.hpp
+++ b/vgl_image.hpp
@@ -6,7 +6,7 @@
 #include "vgl_rand.hpp"
 #include "vgl_vector.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include <sstream>
 #endif
 
@@ -85,7 +85,7 @@ protected:
     /// \param op New data.
     constexpr void replaceData(vector<float>&& op) noexcept
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_data.size() != op.size())
         {
             VGL_THROW_RUNTIME_ERROR("replacing data size " + to_string(op.size()) + " does not match data size " +
@@ -102,7 +102,7 @@ public:
     /// \param value Value to clear to (default: 0.0f).
     void clear(unsigned channel, float value = 0.0f)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(channel > m_channel_count)
         {
             VGL_THROW_RUNTIME_ERROR("trying to clear channel " + to_string(channel) + " in " +
@@ -152,7 +152,7 @@ public:
             return ret;
         }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(bpc != 1)
         {
             VGL_THROW_RUNTIME_ERROR("invalid bpc value for UNORM conversion: " + to_string(bpc));
@@ -228,7 +228,6 @@ public:
     }
 
 #if !defined(VGL_DISABLE_RAND)
-
     /// Fill image with noise.
     ///
     /// \param nfloor Noise floor.
@@ -240,7 +239,6 @@ public:
             m_data[ii] = frand(nfloor, nceil);
         }
     }
-
 #endif
 };
 

--- a/vgl_image_2d.hpp
+++ b/vgl_image_2d.hpp
@@ -38,7 +38,7 @@ private:
     /// \param ch Channel index.
     constexpr void accessCheck(unsigned px, unsigned py, unsigned ch) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if((px >= m_width) || (py >= m_height) || (ch >= getChannelCount()))
         {
             VGL_THROW_RUNTIME_ERROR("image " + to_string(m_width) + ";" + to_string(m_height) + ";" +
@@ -132,7 +132,7 @@ public:
     /// \param op Kernel size.
     void filterLowpass(int op)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(4 < getChannelCount())
         {
             VGL_THROW_RUNTIME_ERROR("cannot filter texture with " + to_string(getChannelCount()) + " channels");

--- a/vgl_index_block.hpp
+++ b/vgl_index_block.hpp
@@ -1,5 +1,5 @@
-#ifndef VERBATIM_INDEX_BLOCK
-#define VERBATIM_INDEX_BLOCK
+#ifndef VGL_INDEX_BLOCK_HPP
+#define VGL_INDEX_BLOCK_HPP
 
 namespace vgl
 {

--- a/vgl_ivec3.hpp
+++ b/vgl_ivec3.hpp
@@ -16,7 +16,14 @@ namespace detail
 /// \return Element value.
 constexpr int16_t normalized_float_to_ivec3_element(float op) noexcept
 {
-    return static_cast<int16_t>(iround((op + 1.0f) * (65535.0f / 2.0f)) - 32768);
+    auto ret = iround((op + 1.0f) * (65535.0f / 2.0f)) - 32768;
+#if defined(VGL_USE_LD) && defined(DEBUG)
+    if((ret < -32768) || (ret > 32767))
+    {
+        VGL_THROW_RUNTIME_ERROR("float " + to_string(op) + " mapping outside int16_t range: " + to_string(ret));
+    }
+#endif
+    return static_cast<int16_t>(ret);
 }
 
 }
@@ -154,7 +161,7 @@ public:
         return !(*this == rhs);
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.
@@ -178,7 +185,7 @@ public:
     /// \param rhs Right-hand-side operand.
     /// \param ratio Mixing ratio.
     /// \return Result color.
-    friend ivec3 mix(const ivec3& lhs, const ivec3& rhs, float ratio) noexcept
+    friend constexpr ivec3 mix(const ivec3& lhs, const ivec3& rhs, float ratio) noexcept
     {
         return ivec3(mix(lhs[0], rhs[0], ratio),
                 mix(lhs[1], rhs[1], ratio),

--- a/vgl_logical_face.hpp
+++ b/vgl_logical_face.hpp
@@ -29,7 +29,7 @@ private:
 
     /// Face normal.
     vec3 m_normal
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         = vec3(0.0f, 0.0f, 0.0f)
 #endif
         ;
@@ -204,7 +204,7 @@ private:
       /// \param idx Index to check.
       constexpr void accessCheck(unsigned idx) const
       {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
           if(idx >= m_num_corners)
           {
               VGL_THROW_RUNTIME_ERROR("accessing index " + to_string(idx) + " of a " + to_string(m_num_corners) +
@@ -220,7 +220,7 @@ private:
       /// \param idx Index to remove.
       constexpr void removeCorner(unsigned idx)
       {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
           if(m_num_corners <= 3)
           {
               VGL_THROW_RUNTIME_ERROR("cannot degrade triangle by removing a corner");
@@ -394,7 +394,7 @@ public:
             }
         }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(isQuad() && ((m_indices[0] == m_indices[2]) || (m_indices[1] == m_indices[3])))
         {
             VGL_THROW_RUNTIME_ERROR("degenerate trapezoid quad");
@@ -414,7 +414,7 @@ public:
     /// \param op Target mesh.
     void write(Mesh& op) const
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if((m_num_corners != 3) && (m_num_corners != 4))
         {
             VGL_THROW_RUNTIME_ERROR("don't know how to write face with " + to_string(m_num_corners) + " corners");
@@ -449,8 +449,8 @@ public:
         return *this;
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param ostr Output stream.

--- a/vgl_logical_mesh.cpp
+++ b/vgl_logical_mesh.cpp
@@ -3,7 +3,7 @@
 namespace vgl
 {
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 unsigned int LogicalMesh::g_vertices_erased = 0;
 #endif
 
@@ -20,7 +20,7 @@ namespace
 vec3 perpendiculate(const vec3& dir, const vec3& ref)
 {
     vec3 unit_dir = normalize(dir);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     // Rotate direction vector components once if it's perpendicular to the reference vector.
     float dot_result = dot(unit_dir, normalize(ref));
     if(abs(dot_result) >= 0.999f)
@@ -417,7 +417,7 @@ void LogicalMesh::csgReadData(const int16_t* data)
         switch(command)
         {
         case CsgCommand::VERTEX:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
             {
@@ -541,7 +541,7 @@ void LogicalMesh::csgReadData(const int16_t* data)
             }
             break;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid CSG command: " + to_string(static_cast<int>(command)));
 #endif

--- a/vgl_logical_mesh.hpp
+++ b/vgl_logical_mesh.hpp
@@ -166,7 +166,7 @@ private:
     vector<LogicalFace> m_faces;
 
 private:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Number of vertices erased during logical mesh generation.
     static unsigned int g_vertices_erased;
 #endif
@@ -273,7 +273,7 @@ private:
         unsigned ret = cloneVertex(idx);
         m_vertices[ret].addFaceReference(face);
         bool success = face.replaceVertexIndex(idx, ret);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!success)
         {
             VGL_THROW_RUNTIME_ERROR("replacing a new vertex turned a face degenerate");
@@ -298,7 +298,7 @@ private:
     /// \param op Vertex index.
     void eraseOrphanedVertex(unsigned op)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(!isOrphanedVertex(op))
         {
             VGL_THROW_RUNTIME_ERROR("cannot erase non-orphaned vertex " + to_string(op));
@@ -309,7 +309,7 @@ private:
         {
             m_vertices[op] = move(m_vertices.back());
             unsigned erase_count = replaceVertexIndex(m_vertices.size() - 1, op);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(erase_count)
             {
                 VGL_THROW_RUNTIME_ERROR("erasing orphaned vertex turned a face degenerate");
@@ -351,7 +351,7 @@ private:
             }
         }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         // Clear face references to mark vertex really as orphan.
         LogicalVertex& srcVertex = m_vertices[src];
         srcVertex.clearFaceReferences();
@@ -425,7 +425,7 @@ public:
     /// \return Mesh.
     MeshUptr compile(bool removeIdentical = true)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         // Clear all face references to destroy state.
         for(auto& vv : m_vertices)
         {
@@ -562,17 +562,17 @@ public:
 
         /// Write vertex data.
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             bitset<GeometryChannel::COUNT> channels;
 #endif
 
             for(auto& vertex : m_vertices)
             {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
                 bitset<GeometryChannel::COUNT> written =
 #endif
                     vertex.write(*ret);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
                 if(channels && (channels != written))
                 {
                     VGL_THROW_RUNTIME_ERROR("channel mismatch between vertices");
@@ -779,8 +779,8 @@ private:
         return static_cast<LogicalMesh*>(op)->createMesh();
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Move operator.
     ///
     /// \param other Source object.
@@ -793,8 +793,8 @@ public:
     }
 #endif
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.
@@ -809,7 +809,7 @@ public:
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_logical_mesh.cpp"
 #endif
 

--- a/vgl_logical_vertex.hpp
+++ b/vgl_logical_vertex.hpp
@@ -5,7 +5,7 @@
 #include "vgl_mesh.hpp"
 #include "vgl_vector.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_bitset.hpp"
 #endif
 
@@ -195,7 +195,7 @@ public:
     /// \param op Face.
     void addFaceReference(LogicalFace *op)
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         for(const auto& vv : m_face_references)
         {
             if(vv == op)
@@ -218,14 +218,14 @@ public:
     /// \param op face.
     void removeFaceReference(LogicalFace* op)
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         bool face_found = false;
 #endif
         for(unsigned ii = 0; (ii < m_face_references.size());)
         {
             if(m_face_references[ii] == op)
             {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
                 if(face_found)
                 {
                     VGL_THROW_RUNTIME_ERROR("face reference found multiple times");
@@ -236,7 +236,7 @@ public:
                     m_face_references[ii] = m_face_references.back();
                 }
                 m_face_references.pop_back();
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
                 continue;
 #else
                 return;
@@ -402,29 +402,33 @@ public:
     /// Write this vertex into a mesh.
     ///
     /// \param op Mesh to write to.
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     bitset<static_cast<unsigned>(GeometryChannel::COUNT)>
 #else
         void
 #endif
         write(Mesh& op) const
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         bitset<GeometryChannel::COUNT> ret(GeometryChannel::POSITION);
 #endif
         op.write(GeometryChannel::POSITION, m_position);
 
         if(m_normal)
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             ret.set(GeometryChannel::NORMAL);
 #endif
+#if defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
             op.write(GeometryChannel::NORMAL, ivec3(*m_normal));
+#else
+            op.write(GeometryChannel::NORMAL, *m_normal);
+#endif
         }
 
         if(m_texcoord)
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             ret.set(GeometryChannel::TEXCOORD);
 #endif
             op.write(GeometryChannel::TEXCOORD, *m_texcoord);
@@ -432,7 +436,7 @@ public:
 
         if(m_color)
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             ret.set(GeometryChannel::COLOR);
 #endif
             op.write(GeometryChannel::COLOR, *m_color);
@@ -440,7 +444,7 @@ public:
 
         if(m_bone_ref)
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             ret.set(GeometryChannel::BONE_WEIGHT);
             ret.set(GeometryChannel::BONE_REF);
 #endif
@@ -450,7 +454,7 @@ public:
 
         op.endVertex();
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         return ret;
 #endif
     }
@@ -471,7 +475,7 @@ public:
     }
 
 public:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Stream output operator.
     ///
     /// \param ostr Output stream.

--- a/vgl_mat2.hpp
+++ b/vgl_mat2.hpp
@@ -33,7 +33,7 @@ public:
     /// Create an identity matrix.
     ///
     /// \return Result matrix.
-    static mat2 identity() noexcept
+    constexpr static mat2 identity() noexcept
     {
         return mat2(1.0f, 0.0f,
                 0.0f, 1.0f);
@@ -42,7 +42,7 @@ public:
     /// Create a rotation matrix.
     ///
     /// \param op Rotation.
-    static mat2 rotation(float op)
+    VGL_MATH_CONSTEXPR static mat2 rotation(float op)
     {
         float sr = sin(op);
         float cr = cos(op);
@@ -51,8 +51,8 @@ public:
                 -sr, cr);
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Output to stream.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_mat3.hpp
+++ b/vgl_mat3.hpp
@@ -64,22 +64,6 @@ private:
     }
 
 public:
-#if defined(USE_LD)
-    /// Output to stream.
-    ///
-    /// \param lhs Left-hand-side operand.
-    /// \param rhs Right-hand-side operand.
-    /// \return Output stream.
-    friend std::ostream& operator<<(std::ostream& lhs, const mat3& rhs)
-    {
-        return lhs << "[ " <<
-            rhs[0u] << " ; " << rhs[3u] << " ; " << rhs[6u] << "\n  " <<
-            rhs[1u] << " ; " << rhs[4u] << " ; " << rhs[7u] << "\n  " <<
-            rhs[2u] << " ; " << rhs[5u] << " ; " << rhs[8u] << " ]";
-    }
-#endif
-
-public:
     /// Create an identity matrix.
     ///
     /// \return Result matrix.
@@ -135,6 +119,22 @@ public:
     {
         return rotation_zxy(pitch, yaw, roll);
     }
+
+#if defined(VGL_USE_LD)
+public:
+    /// Output to stream.
+    ///
+    /// \param lhs Left-hand-side operand.
+    /// \param rhs Right-hand-side operand.
+    /// \return Output stream.
+    friend std::ostream& operator<<(std::ostream& lhs, const mat3& rhs)
+    {
+        return lhs << "[ " <<
+            rhs[0u] << " ; " << rhs[3u] << " ; " << rhs[6u] << "\n  " <<
+            rhs[1u] << " ; " << rhs[4u] << " ; " << rhs[7u] << "\n  " <<
+            rhs[2u] << " ; " << rhs[5u] << " ; " << rhs[8u] << " ]";
+    }
+#endif
 };
 
 /// Transpose a matrix.

--- a/vgl_mat4.hpp
+++ b/vgl_mat4.hpp
@@ -312,8 +312,8 @@ public:
         return translation(pos[0u], pos[1u], pos[2u]);
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Output to stream.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_mesh.hpp
+++ b/vgl_mesh.hpp
@@ -25,7 +25,7 @@ private:
     /// Bounding box for the mesh.
     BoundingBox m_box;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Name of the mesh, for debugging.
     string m_name;
 #endif
@@ -90,7 +90,7 @@ public:
     /// \param op Program to draw with.
     void draw(const GlslProgram& op) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(!m_handle)
         {
             VGL_THROW_RUNTIME_ERROR("cannot draw mesh with invalid geometry handle");
@@ -115,6 +115,8 @@ public:
         m_data.write(op);
     }
 
+#if defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
+
     /// Write vertex data with semantic.
     ///
     /// \param channel Associated channel.
@@ -123,6 +125,8 @@ public:
     {
         m_data.write(channel, data);
     }
+
+#endif
 
     /// Write vertex data with semantic.
     ///
@@ -182,7 +186,7 @@ public:
         m_handle = GeometryHandle(*(g_geometry_buffers.back()), 0, 0);
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Accessor.
     ///
     /// \return Name.
@@ -220,7 +224,7 @@ constexpr unsigned get_num_geometry_buffers()
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_mesh.cpp"
 #endif
 

--- a/vgl_mesh_data.hpp
+++ b/vgl_mesh_data.hpp
@@ -5,12 +5,15 @@
 #include "vgl_buffer.hpp"
 #include "vgl_geometry_handle.hpp"
 #include "vgl_glsl_program.hpp"
-#include "vgl_ivec3.hpp"
 #include "vgl_packed_data.hpp"
 #include "vgl_state.hpp"
 #include "vgl_vec2.hpp"
 #include "vgl_vec3.hpp"
 #include "vgl_uvec4.hpp"
+
+#if defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
+#include "vgl_ivec3.hpp"
+#endif
 
 namespace vgl
 {
@@ -113,7 +116,7 @@ public:
             return !(*this == op);
         }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         /// To string operator.
         ///
         /// \param op Input object.
@@ -278,6 +281,8 @@ public:
         m_index_data.push_back(op);
     }
 
+#if defined(VGL_ENABLE_VERTEX_NORMAL_PACKING)
+
     /// Write vertex data with semantic.
     ///
     /// \param channel Associated channel.
@@ -287,6 +292,8 @@ public:
         setChannel(channel, getVertexOffset());
         m_vertex_data.push(data);
     }
+
+#endif
 
     /// Write vertex data with semantic.
     ///
@@ -323,7 +330,7 @@ public:
     /// \param op Another data block.
     void append(const MeshData& op)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if((m_vertex_count + op.getVertexCount()) > 0xFFFFu)
         {
             VGL_THROW_RUNTIME_ERROR("trying to merge mesh data sets beyond 16 bit index scope");
@@ -345,7 +352,7 @@ public:
     /// \param op Program to bind with.
     void bindAttributes(const GlslProgram& op) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         constexpr unsigned MAX_ATTRIB_ARRAYS = 8;
         bitset<MAX_ATTRIB_ARRAYS> bound_attributes;
 #endif
@@ -355,14 +362,14 @@ public:
             int idx = vv.bind(op, m_stride);
             if(idx >= 0)
             {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
                 VGL_ASSERT(static_cast<unsigned>(idx) < MAX_ATTRIB_ARRAYS);
                 bound_attributes[idx] = true;
 #endif
             }
         }
 
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         bool disabled_found = false;
         for(unsigned ii = 0; (ii < MAX_ATTRIB_ARRAYS); ++ii)
         {
@@ -411,7 +418,7 @@ public:
 namespace detail
 {
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Increment data sizes by given mesh data size.
 ///

--- a/vgl_mutex.hpp
+++ b/vgl_mutex.hpp
@@ -8,7 +8,7 @@
 #include "vgl_extern_sdl.hpp"
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #include <ostream>
 #endif
@@ -50,7 +50,7 @@ public:
     {
 #if defined(VGL_ENABLE_GTK)
         dnload_g_mutex_init(m_mutex);
-#elif defined(USE_LD) && defined(DEBUG)
+#elif defined(VGL_USE_LD) && defined(DEBUG)
         if(!m_mutex)
         {
             VGL_THROW_RUNTIME_ERROR(string("Mutex::Mutex(): ") + SDL_GetError());
@@ -127,7 +127,7 @@ public:
         dnload_g_mutex_lock(op);
 #else
         int err = dnload_SDL_LockMutex(op);
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR(string("internal_mutex_acquire(): ") + SDL_GetError());
@@ -147,7 +147,7 @@ public:
         dnload_g_mutex_unlock(op);
 #else
         int err = dnload_SDL_UnlockMutex(op);
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR(string("internal_mutex_release(): ") + SDL_GetError());
@@ -171,8 +171,8 @@ public:
         return *this;
     }
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_optional.hpp
+++ b/vgl_optional.hpp
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <optional>
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif
 
@@ -230,7 +230,7 @@ private:
     /// Throws an error if the optional value is not initialized.
     constexpr void accessCheck() const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(!has_value())
         {
             VGL_THROW_RUNTIME_ERROR("optional value is uninitialized");

--- a/vgl_opus.hpp
+++ b/vgl_opus.hpp
@@ -14,7 +14,7 @@
 #include "opus.h"
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif
 
@@ -60,7 +60,7 @@ public:
     /// Destructor.
     ~OggReader()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         ogg_sync_clear(&m_sync);
 #endif
     }
@@ -93,7 +93,7 @@ public:
             m_pos += increment;
 
             int err = dnload_ogg_sync_wrote(&m_sync, static_cast<long>(increment));
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(err)
             {
                 VGL_THROW_RUNTIME_ERROR("ogg_sync_wrote() failed: " + to_string(err));
@@ -125,7 +125,7 @@ public:
         ogg_page page;
         {
             bool err = m_reader.read(page);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(!err)
             {
                 VGL_THROW_RUNTIME_ERROR("OggStream input did not contain even one page");
@@ -137,7 +137,7 @@ public:
 
         // First page must correspond to the opus stream.
         int serial = dnload_ogg_page_serialno(&page);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         {
             int err = ogg_page_bos(&page);
             if(!err)
@@ -149,7 +149,7 @@ public:
 
         {
             int err = dnload_ogg_stream_init(&m_stream_state, serial);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(err)
             {
                 VGL_THROW_RUNTIME_ERROR("ogg_stream_init() failed: " + to_string(err));
@@ -165,7 +165,7 @@ public:
     /// Destructor.
     ~OggStream()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         int err = ogg_stream_clear(&m_stream_state);
         if(err)
         {
@@ -194,7 +194,7 @@ public:
                 submitPage(page);
                 continue;
             }
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(err != 1)
             {
                 VGL_THROW_RUNTIME_ERROR("ogg_stream_packetout() error: " + to_string(err));
@@ -210,7 +210,7 @@ private:
     void submitPage(ogg_page& page)
     {
         int err = dnload_ogg_stream_pagein(&m_stream_state, &page);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(err)
         {
             VGL_THROW_RUNTIME_ERROR("ogg_stream_pagein() packet submission error: " + to_string(err));
@@ -229,7 +229,7 @@ unsigned opus_read_ogg_header(OggStream& stream)
 {
     ogg_packet packet;
     bool err = stream.readPacket(packet);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     if(!err)
     {
         VGL_THROW_RUNTIME_ERROR("could not read opus header");
@@ -242,7 +242,7 @@ unsigned opus_read_ogg_header(OggStream& stream)
 
     // Comment packet is just discarded.
     err = stream.readPacket(packet);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     if(!err)
     {
         VGL_THROW_RUNTIME_ERROR("could not read opus comment");
@@ -273,7 +273,7 @@ vector<float> opus_read_ogg_memory(const void* input, unsigned size, int channel
 
     int err;
     OpusDecoder* decoder = dnload_opus_decoder_create(48000, channels, &err);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     if(err != OPUS_OK)
     {
         VGL_THROW_RUNTIME_ERROR("opus_decoder_create() failed: " + to_string(err));
@@ -292,7 +292,7 @@ vector<float> opus_read_ogg_memory(const void* input, unsigned size, int channel
 
         err = dnload_opus_decode_float(decoder, packet.packet, static_cast<opus_int32>(packet.bytes), output,
                 detail::OPUS_MAX_PACKET_SIZE_48000, 0);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(err <= 0)
         {
             VGL_THROW_RUNTIME_ERROR("opus_decode_float() error: " + to_string(err));
@@ -314,7 +314,7 @@ vector<float> opus_read_ogg_memory(const void* input, unsigned size, int channel
         }
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     opus_decoder_destroy(decoder);
 #endif
     return ret;
@@ -335,7 +335,7 @@ vector<float> opus_read_raw_memory(const void* input, unsigned size, int channel
 
     int err;
     OpusDecoder* decoder = dnload_opus_decoder_create(48000, channels, &err);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     if(err != OPUS_OK)
     {
         VGL_THROW_RUNTIME_ERROR("opus_decoder_create() failed: " + to_string(err));
@@ -353,7 +353,7 @@ vector<float> opus_read_raw_memory(const void* input, unsigned size, int channel
         input_iter += 2;
 
         err = dnload_opus_decode_float(decoder, input_iter, bytes, output, detail::OPUS_MAX_PACKET_SIZE_48000, 0);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(err <= 0)
         {
             VGL_THROW_RUNTIME_ERROR("opus_decode_float() error: " + to_string(err));
@@ -379,7 +379,7 @@ vector<float> opus_read_raw_memory(const void* input, unsigned size, int channel
         VGL_ASSERT(input_iter <= iter_end);
     } while(input_iter != iter_end);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     opus_decoder_destroy(decoder);
 #endif
     return ret;

--- a/vgl_packed_data_reader.hpp
+++ b/vgl_packed_data_reader.hpp
@@ -77,7 +77,7 @@ public:
     /// \return Reference to type stored in the packed data.
     template<typename T> constexpr const T& read(unsigned op = 1) noexcept
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(remaining() < sizeof(T))
         {
             VGL_THROW_RUNTIME_ERROR("cannot read value of size " + to_string(sizeof(T)) + ": " +

--- a/vgl_quat.hpp
+++ b/vgl_quat.hpp
@@ -211,7 +211,7 @@ public:
         return rhs * lhs;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Output to stream.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_rand.hpp
+++ b/vgl_rand.hpp
@@ -25,7 +25,7 @@ float frand(float lo, float hi);
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_rand.cpp"
 #endif
 

--- a/vgl_realloc.cpp
+++ b/vgl_realloc.cpp
@@ -2,7 +2,7 @@
 
 #include <new>
 
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
 #include <iostream>
 #endif
 
@@ -21,7 +21,7 @@ void operator delete(void *ptr, size_t align) noexcept
 
 void* operator new(size_t sz)
 {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
     if(!sz)
     {
         std::cerr << "WARNING: call to new() with size 0" << std::endl;
@@ -32,7 +32,7 @@ void* operator new(size_t sz)
 
 void* operator new(size_t sz, size_t align)
 {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
     if(!sz)
     {
         std::cerr << "WARNING: call to new() with size 0" << std::endl;
@@ -42,7 +42,7 @@ void* operator new(size_t sz, size_t align)
     (void)align;
 }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 void operator delete[](void *ptr) noexcept
 {

--- a/vgl_realloc.hpp
+++ b/vgl_realloc.hpp
@@ -62,7 +62,7 @@ constexpr void* internal_memset(void* ptr, int value, unsigned count)
 /// \return (re)Allocated pointer.
 inline void* array_new_internal(void* ptr, size_t new_size)
 {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     if(!new_size)
     {
         // Can't use vgl_throw_exception.hpp yet.
@@ -70,7 +70,7 @@ inline void* array_new_internal(void* ptr, size_t new_size)
     }
 #endif
     void* ret = dnload_realloc(ptr, new_size);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     if(!ret)
     {
         // Can't use vgl_throw_exception.hpp yet.
@@ -110,7 +110,7 @@ template <typename T> inline T* array_new(T* ptr, size_t count)
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_realloc.cpp"
 #endif
 

--- a/vgl_render_queue.hpp
+++ b/vgl_render_queue.hpp
@@ -78,7 +78,7 @@ private:
                 return;
             }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(!m_program)
             {
                 VGL_THROW_RUNTIME_ERROR("cannot apply mesh before a program has been set");
@@ -114,7 +114,7 @@ private:
         /// \return Uniform location.
         GLint getUniformLocation(PackedDataReader& iter)
         {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(!m_program)
             {
                 VGL_THROW_RUNTIME_ERROR("cannot get uniform locations before a program has been read");
@@ -301,21 +301,21 @@ private:
     PackedData m_data;
 
     /// Current camera settings.
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     optional<mat4> m_camera_matrix;
 #else
     mat4 m_camera_matrix;
 #endif
 
     /// Current projection + camera settings.
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     optional<mat4> m_projection_camera_matrix;
 #else
     mat4 m_projection_camera_matrix;
 #endif
 
     /// Current camera position.
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     optional<vec3> m_camera_position;
 #else
     vec3 m_camera_position;
@@ -376,7 +376,7 @@ public:
     void clear()
     {
         m_data.clear();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_camera_matrix = nullopt;
         m_projection_camera_matrix = nullopt;
         m_camera_position = nullopt;
@@ -409,7 +409,7 @@ public:
         m_data.push(&msh);
         m_data.push(modelview);
         m_data.push(normalify(modelview));
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_data.push((*m_camera_matrix) * modelview);
         m_data.push((*m_projection_camera_matrix) * modelview);
 #else
@@ -436,7 +436,7 @@ public:
     {
         mat4 camera = viewify(cam);
         m_camera_matrix = camera;
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_projection_camera_matrix = proj * (*m_camera_matrix);
 #else
         m_projection_camera_matrix = proj * m_camera_matrix;
@@ -446,7 +446,7 @@ public:
         pushCommand<&RenderState::commandView>();
         m_data.push(proj);
         m_data.push(range);
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_data.push(*m_camera_matrix);
         m_data.push(*m_projection_camera_matrix);
         m_data.push(*m_camera_position);

--- a/vgl_spline.hpp
+++ b/vgl_spline.hpp
@@ -91,7 +91,7 @@ public:
     /// \param stamp Timestamp.
     void addPoint(const vec3 &pos, float stamp)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(0.0f > stamp)
         {
             VGL_THROW_RUNTIME_ERROR("tried to add spline point with invalid timestamp: " + to_string(stamp));
@@ -136,7 +136,7 @@ public:
     /// \param stamp Timestamp to get position for.
     constexpr vec3 resolvePosition(float stamp)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_points.empty())
         {
             VGL_THROW_RUNTIME_ERROR("incorrect spline data");

--- a/vgl_state.cpp
+++ b/vgl_state.cpp
@@ -20,13 +20,13 @@ OpenGlPolygonOffsetState OpenGlPolygonOffsetState::g_opengl_polygon_offset_state
 #if !defined(VGL_DISABLE_STENCIL)
 OpenGlStencilState OpenGlStencilState::g_opengl_stencil_state;
 #endif
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 OpenGlDiagnosticsState OpenGlDiagnosticsState::g_opengl_diagnostics_state;
 #endif
 
 }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 string to_string(OperationMode op)
 {

--- a/vgl_state.hpp
+++ b/vgl_state.hpp
@@ -5,7 +5,7 @@
 #include "vgl_optional.hpp"
 #include "vgl_uvec4.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include <sstream>
 #endif
 
@@ -31,7 +31,7 @@ enum OperationMode
     CARMACK,
 };
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// Converts an operation mode to string.
 ///
@@ -87,7 +87,7 @@ public:
                 }
                 else // Default is premultiplied.
                 {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
                     if(op != PREMULTIPLIED)
                     {
                         VGL_THROW_RUNTIME_ERROR("invalid blend mode: '" + to_string(op) + "'");
@@ -413,7 +413,7 @@ public:
             }
             else // Default is nothing.
             {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
                 if(op != DISABLED)
                 {
                     VGL_THROW_RUNTIME_ERROR("invalid stencil operation: '" + to_string(op) + "'");
@@ -428,7 +428,7 @@ public:
 
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 /// OpenGL state abstraction.
 class OpenGlDiagnosticsState
@@ -616,7 +616,7 @@ inline void stencil_operation(OperationMode op)
 
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 
 #if !defined(VGL_DISABLE_EDGE)
 
@@ -749,7 +749,7 @@ void error_check(const char* str = NULL);
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_state.cpp"
 #endif
 

--- a/vgl_string.hpp
+++ b/vgl_string.hpp
@@ -5,7 +5,7 @@
 #include "vgl_limits.hpp"
 #include "vgl_realloc.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_utility.hpp"
 #include <ostream>
 #endif
@@ -74,7 +74,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(unsigned idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx >= m_length)
         {
             // Can't use vgl_throw_exception.hpp yet.
@@ -90,7 +90,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(int idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx < 0)
         {
             // Can't use vgl_throw_exception.hpp yet.
@@ -160,7 +160,7 @@ public:
         return reinterpret_cast<const T*>("");
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Finds the occurrance of another substring.
     ///
     /// \param rhs Right-hand side operand.
@@ -294,7 +294,7 @@ public:
         return !(*this == rhs);
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Less than operator.
     ///
     /// \param rhs Right-hand-side operand.
@@ -319,8 +319,8 @@ public:
     }
 #endif
 
+#if defined(VGL_USE_LD)
 public:
-#if defined(USE_LD)
     /// Conversion to STL string operator.
     ///
     /// \return STL string.
@@ -335,7 +335,10 @@ public:
     {
         return std::string_view(data(), length());
     }
+#endif
 
+#if defined(VGL_USE_LD)
+public:
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.
@@ -395,7 +398,7 @@ public:
         assign(op);
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Constructor from std::string.
     ///
     /// Intentionally not explicit.
@@ -463,7 +466,7 @@ public:
         base_type::m_data = op.m_data;
         base_type::m_length = op.m_length;
         op.m_data = nullptr;
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         op.m_length = 0;
 #endif
         return *this;
@@ -484,7 +487,7 @@ public:
     string& assign(const char* data, unsigned len)
     {
         VGL_ASSERT(data || (len == 0));
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(length() == len)
         {
             detail::internal_memcpy(base_type::m_data, data, len);
@@ -580,7 +583,7 @@ public:
         }
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Erase a part of the string.
     ///
     /// \param start_iter Starting iterator to erase from.
@@ -695,7 +698,7 @@ public:
         return assign(rhs.data(), rhs.length());
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Addition operator.
     ///
     /// \param rhs Right-hand-side operand.
@@ -804,7 +807,7 @@ public:
 #endif
 };
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 namespace detail
 {
 

--- a/vgl_task.hpp
+++ b/vgl_task.hpp
@@ -115,7 +115,7 @@ public:
         {
             m_fence_data->setReturnValue(ret);
         }
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         else if(ret)
         {
             std::cerr << "Task::operator(): unhandled return value '" << ret << "'" << std::endl;

--- a/vgl_task_dispatcher.hpp
+++ b/vgl_task_dispatcher.hpp
@@ -6,7 +6,7 @@
 #include "vgl_thread.hpp"
 #include "vgl_vector.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include <sstream>
 #endif
 
@@ -47,7 +47,7 @@ private:
     /// Number of threads waiting for tasks to execute.
     unsigned m_threads_waiting = 0;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Flag signifying the task queue is being destroyed.
     ///
     /// The flag is disabled for optimized build, because the program should never exit cleanly.
@@ -61,7 +61,7 @@ public:
     /// Destructor.
     ~InternalTaskDispatcher()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #if defined(DEBUG)
         if(!m_mutex.getMutexImpl())
         {
@@ -159,7 +159,7 @@ private:
     /// Thread that has not entered execution is considered waiting.
     void spawnThread()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         string threadName = "InternalTaskDispatcher(" + to_string(m_threads.size()) + ")";
         m_threads.emplace_back(task_thread_func, this, threadName.c_str());
 #else
@@ -186,7 +186,7 @@ private:
         ScopedAcquire sa(m_mutex);
         --m_threads_waiting;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         while(!m_quitting)
 #else
         for(;;)
@@ -236,7 +236,7 @@ public:
     {
         ScopedAcquire sa(m_mutex);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         while(!m_quitting)
 #else
         for(;;)
@@ -278,7 +278,7 @@ public:
         // Fence may have turned inactive before the wait point is reached.
         if(op)
         {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
             if(isMainThread())
             {
                 VGL_THROW_RUNTIME_ERROR("cannot wait on main thread");
@@ -483,7 +483,7 @@ inline void* internal_fence_wait(Fence& op)
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_task_dispatcher.cpp"
 #endif
 

--- a/vgl_task_queue.hpp
+++ b/vgl_task_queue.hpp
@@ -41,7 +41,7 @@ public:
     void uninitialize()
     {
         m_cond.broadcast();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         while(!m_tasks.empty())
         {
             m_tasks.pop();

--- a/vgl_texture.hpp
+++ b/vgl_texture.hpp
@@ -3,7 +3,7 @@
 
 #include "vgl_extern_opengl.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif
 
@@ -88,7 +88,7 @@ public:
     /// Destructor.
     ~Texture()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         unbind();
 
         glDeleteTextures(1, &m_id);
@@ -185,7 +185,7 @@ protected:
         {
             texture->bind(g_active_texture_unit);
         }
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         else
         {
             unbind();
@@ -193,7 +193,7 @@ protected:
 #endif
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Unbind texture from whichever texture unit it's bound to.
     void unbind() const
     {
@@ -219,7 +219,7 @@ public:
     /// \param op Unit to bind to.
     void bind(unsigned op) const
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(op >= MAX_TEXTURE_UNITS)
         {
             VGL_THROW_RUNTIME_ERROR("trying to bind to texture unit index " + to_string(op) + " of maximum " +
@@ -267,7 +267,7 @@ private:
 
 }
 
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
 #include "vgl_texture.cpp"
 #endif
 

--- a/vgl_texture_2d.hpp
+++ b/vgl_texture_2d.hpp
@@ -160,7 +160,7 @@ public:
                 static_cast<GLsizei>(width), static_cast<GLsizei>(height),
                 0, format.getFormat(), format.getType(), data);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         unsigned data_size = width * height * format.getTypeSize();
         if(setFiltering(data, filtering))
         {
@@ -171,7 +171,7 @@ public:
 #endif
         setWrapMode(wrap);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         vgl::increment_data_size_texture(data_size);
 #endif
 

--- a/vgl_texture_3d.hpp
+++ b/vgl_texture_3d.hpp
@@ -1,5 +1,5 @@
-#ifndef VERBATIM_TEXTURE_3D_HPP
-#define VERBATIM_TEXTURE_3D_HPP
+#ifndef VGL_TEXTURE_3D_HPP
+#define VGL_TEXTURE_3D_HPP
 
 #include "verbatim_image_3d.hpp"
 #include "verbatim_texture.hpp"
@@ -48,7 +48,7 @@ class Texture3D : public Texture
           static_cast<GLsizei>(width), static_cast<GLsizei>(height), static_cast<GLsizei>(depth),
           0, format.getFormat(), format.getType(), data);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
       unsigned data_size = width * height * depth * format.getTypeSize();
       if(setFiltering(data, filtering))
       {
@@ -59,7 +59,7 @@ class Texture3D : public Texture
 #endif
       setWrapMode(wrap);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
       vgl::increment_data_size_texture(data_size);
 #endif
 

--- a/vgl_texture_cube.hpp
+++ b/vgl_texture_cube.hpp
@@ -1,11 +1,11 @@
-#ifndef VERBATIM_TEXTURE_CUBE_HPP
-#define VERBATIM_TEXTURE_CUBE_HPP
+#ifndef VGL_TEXTURE_CUBE_HPP
+#define VGL_TEXTURE_CUBE_HPP
 
 /// Cube map  texture.
 class TextureCube : public Texture
 {
 private:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Side size in pixels.
     unsigned int m_side = 0;
 #endif
@@ -27,7 +27,7 @@ private:
         TextureFormat format(img.getChannelCount(), bpc, reinterpret_cast<void*>(1u));
 
         unsigned width = img.getWidth();
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         {
             unsigned height = img.getHeight();
             if(width != height)

--- a/vgl_texture_format.hpp
+++ b/vgl_texture_format.hpp
@@ -1,7 +1,7 @@
 #ifndef VGL_TEXTURE_FORMAT_HPP
 #define VGL_TEXTURE_FORMAT_HPP
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_string.hpp"
 #include <ios>
 #endif
@@ -28,7 +28,7 @@ protected:
     /// OpenGL type.
     GLenum m_type;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Size of one texel in bytes.
     unsigned m_type_size = 0;
 #endif
@@ -71,7 +71,7 @@ public:
         return m_type;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Accessor.
     ///
     /// \return Data size multiplier.
@@ -89,7 +89,7 @@ public:
 #endif
 
 public:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Converts TextureFormat to a string.
     ///
     /// \param op Input.
@@ -126,7 +126,7 @@ public:
     constexpr explicit TextureFormatColor(unsigned channels, unsigned bpc, void* data) :
         TextureFormat(determine_format(channels), determine_internal_format(channels, bpc, data), determine_type(channels, bpc, data))
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if (m_type == GL_UNSIGNED_SHORT_5_6_5)
         {
             m_type_size = 2;
@@ -165,12 +165,12 @@ private:
             return GL_RGB;
 
         case 4:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
             return GL_RGBA;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid color channel count: " + to_string(channels));
 #endif
@@ -197,12 +197,12 @@ private:
             return determine_internal_format_rgb(bpc, data);
 
         case 4:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
             return determine_internal_format_rgba(bpc, data);
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid color channel count: " + to_string(channels));
 #endif
@@ -234,7 +234,7 @@ private:
 #endif
 
         case 1:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
 #if defined(DNLOAD_GLESV2)
@@ -243,7 +243,7 @@ private:
             return GL_R8;
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid bytes per channel for R format: " + to_string(bpc));
 #endif
@@ -275,7 +275,7 @@ private:
 #endif
 
         case 1:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
 #if defined(DNLOAD_GLESV2)
@@ -284,7 +284,7 @@ private:
             return GL_RG8;
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid bytes per channel for RG format: " + to_string(bpc));
 #endif
@@ -324,7 +324,7 @@ private:
 #endif
 
         case 1:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
 #if defined(DNLOAD_GLESV2)
@@ -333,7 +333,7 @@ private:
             return GL_RGB8;
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid bytes per channel for RGB format: " + to_string(bpc));
 #endif
@@ -365,7 +365,7 @@ private:
 #endif
 
         case 1:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
 #if defined(DNLOAD_GLESV2)
@@ -374,7 +374,7 @@ private:
             return GL_RGBA8;
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid bytes per channel for RGBA format: " + to_string(bpc));
 #endif
@@ -399,23 +399,23 @@ private:
 
             // Special case: packed data.
         case 0:
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             if(channels == 3)
 #endif
             {
                 return GL_UNSIGNED_SHORT_5_6_5;
             }
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
             VGL_THROW_RUNTIME_ERROR("invalid channel count for special packed format: " + to_string(channels));
 #endif
 
         case 1:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
             return GL_UNSIGNED_BYTE;
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("bytes per channel for determining type: " + to_string(bpc));
 #endif
@@ -433,7 +433,7 @@ public:
     constexpr explicit TextureFormatDepth(unsigned bpc) :
         TextureFormat(determine_format(), determine_internal_format(bpc), determine_type(bpc))
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         m_type_size = bpc;
 #endif
     }
@@ -472,7 +472,7 @@ private:
 #endif
 
         case 4:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
 #if defined(DNLOAD_GLESV2) && !defined(VGL_DISABLE_DEPTH_TEXTURE)
@@ -483,7 +483,7 @@ private:
             return GL_DEPTH_COMPONENT32F;
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid bytes per channel for depth format: " + to_string(bpc));
 #endif
@@ -505,7 +505,7 @@ private:
             return GL_UNSIGNED_INT;
 
         case 4:
-#if !defined(USE_LD)
+#if !defined(VGL_USE_LD)
         default:
 #endif
 #if defined(DNLOAD_GLESV2) && !defined(VGL_DISABLE_DEPTH_TEXTURE)
@@ -514,7 +514,7 @@ private:
             return GL_FLOAT;
 #endif
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         default:
             VGL_THROW_RUNTIME_ERROR("invalid bytes per channel for depth format: " + to_string(bpc));
 #endif

--- a/vgl_throw_exception.hpp
+++ b/vgl_throw_exception.hpp
@@ -1,7 +1,9 @@
 #ifndef VGL_THROW_EXCEPTION_HPP
 #define VGL_THROW_EXCEPTION_HPP
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "vgl_string.hpp"
 

--- a/vgl_type_traits.hpp
+++ b/vgl_type_traits.hpp
@@ -1,6 +1,8 @@
 #ifndef VGL_TYPE_TRAITS_HPP
 #define VGL_TYPE_TRAITS_HPP
 
+#include "vgl_config.hpp"
+
 #include <type_traits>
 
 #if __cplusplus > 201703L && !defined(__clang__)

--- a/vgl_uvec4.hpp
+++ b/vgl_uvec4.hpp
@@ -16,7 +16,14 @@ namespace detail
 /// \return Element value.
 constexpr uint8_t normalized_float_to_uvec4_element(float op) noexcept
 {
-    return static_cast<uint8_t>(iround(op * 255.0f));
+    auto ret = iround(op * 255.0f);
+#if defined(VGL_USE_LD) && defined(DEBUG)
+    if((ret < 0) || (ret > 255))
+    {
+        VGL_THROW_RUNTIME_ERROR("float " + to_string(op) + " mapping outside uint8_t range: " + to_string(ret));
+    }
+#endif
+    return static_cast<uint8_t>(ret);
 }
 
 }
@@ -177,7 +184,35 @@ public:
         return !(*this == rhs);
     }
 
-#if defined(USE_LD)
+public:
+    /// Mix two vectors.
+    ///
+    /// \param lhs Left-hand-side operand.
+    /// \param rhs Right-hand-side operand.
+    /// \param ratio Mixing ratio.
+    /// \return Result color.
+    friend constexpr uvec4 mix(const uvec4& lhs, const uvec4& rhs, float ratio) noexcept
+    {
+        return uvec4(mix(lhs[0], rhs[0], ratio),
+                mix(lhs[1], rhs[1], ratio),
+                mix(lhs[2], rhs[2], ratio),
+                mix(lhs[3], rhs[3], ratio));
+    }
+
+    /// Modulate two vectors.
+    ///
+    /// \param lhs Left-hand-side operand.
+    /// \param rhs Right-hand-side operand.
+    /// \return Result color.
+    friend constexpr uvec4 modulate(const uvec4& lhs, const uvec4& rhs) noexcept
+    {
+        return uvec4(modulate(lhs[0], rhs[0]),
+                modulate(lhs[1], rhs[1]),
+                modulate(lhs[2], rhs[2]),
+                modulate(lhs[3], rhs[3]));
+    }
+
+#if defined(VGL_USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.
@@ -193,34 +228,6 @@ public:
         return lhs << " ]";
     }
 #endif
-
-public:
-    /// Mix two vectors.
-    ///
-    /// \param lhs Left-hand-side operand.
-    /// \param rhs Right-hand-side operand.
-    /// \param ratio Mixing ratio.
-    /// \return Result color.
-    friend uvec4 mix(const uvec4& lhs, const uvec4& rhs, float ratio) noexcept
-    {
-        return uvec4(mix(lhs[0], rhs[0], ratio),
-                mix(lhs[1], rhs[1], ratio),
-                mix(lhs[2], rhs[2], ratio),
-                mix(lhs[3], rhs[3], ratio));
-    }
-
-    /// Modulate two vectors.
-    ///
-    /// \param lhs Left-hand-side operand.
-    /// \param rhs Right-hand-side operand.
-    /// \return Result color.
-    friend uvec4 modulate(const uvec4& lhs, const uvec4& rhs) noexcept
-    {
-        return uvec4(modulate(lhs[0], rhs[0]),
-                modulate(lhs[1], rhs[1]),
-                modulate(lhs[2], rhs[2]),
-                modulate(lhs[3], rhs[3]));
-    }
 };
 
 }

--- a/vgl_vec.hpp
+++ b/vgl_vec.hpp
@@ -435,7 +435,7 @@ public:
         return !(lhs == rhs);
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Stream output operator.
     ///
     /// \param lhs Left-hand-side operand.

--- a/vgl_vector.hpp
+++ b/vgl_vector.hpp
@@ -6,7 +6,7 @@
 #include "vgl_type_traits.hpp"
 #include "vgl_utility.hpp"
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
 #include "vgl_throw_exception.hpp"
 #endif
 
@@ -65,7 +65,7 @@ public:
         }
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Consructor from iterators.
     ///
     /// \param first First iterator to insert.
@@ -106,7 +106,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(unsigned idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx >= m_size)
         {
             VGL_THROW_RUNTIME_ERROR("accessing index " + to_string(idx) + " from vector of size " +
@@ -121,7 +121,7 @@ private:
     /// \param idx Index to check.
     constexpr void accessCheck(int idx) const
     {
-#if defined(USE_LD) && defined(DEBUG)
+#if defined(VGL_USE_LD) && defined(DEBUG)
         if(idx < 0)
         {
             VGL_THROW_RUNTIME_ERROR("accessing negative index " + to_string(idx) + " from vector of size " +
@@ -375,7 +375,7 @@ public:
         m_size = cnt;
     }
 
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
     /// Swap with another object.
     ///
     /// \param other Object to swap with.

--- a/vgl_vertex_array_object.hpp
+++ b/vgl_vertex_array_object.hpp
@@ -59,7 +59,7 @@ public:
     /// Destructor.
     ~VertexArrayObject()
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         if(m_id)
         {
             detail::OpenGlVertexArrayObjectState::g_opengl_vertex_array_object_state.invalidate(m_id);
@@ -71,10 +71,10 @@ public:
     /// Move constructor.
     ///
     /// \param other Source object.
-    VertexArrayObject(VertexArrayObject&& other) :
+    constexpr VertexArrayObject(VertexArrayObject&& other) :
         m_id(other.m_id)
     {
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         other.m_id = 0;
 #endif
     }
@@ -83,7 +83,7 @@ public:
     /// Accessor.
     ///
     /// \return Identifier.
-    GLuint getId() const
+    constexpr GLuint getId() const
     {
         return m_id;
     }
@@ -99,10 +99,10 @@ public:
     ///
     /// \param other Source object.
     /// \return This object.
-    VertexArrayObject& operator=(VertexArrayObject&& other)
+    constexpr VertexArrayObject& operator=(VertexArrayObject&& other)
     {
         m_id = other.m_id;
-#if defined(USE_LD)
+#if defined(VGL_USE_LD)
         other.m_id = 0;
 #endif
         return *this;

--- a/vgl_wave.cpp
+++ b/vgl_wave.cpp
@@ -1,5 +1,7 @@
 #include "vgl_wave.hpp"
 
+#if defined(VGL_USE_LD)
+
 #include "vgl_filesystem.hpp"
 
 #include <boost/algorithm/string.hpp>
@@ -353,4 +355,6 @@ string wave_preprocess_glsl(string_view op)
 }
 
 }
+
+#endif
 

--- a/vgl_wave.hpp
+++ b/vgl_wave.hpp
@@ -4,7 +4,9 @@
 /// \file boost::wave preprocessing functionality.
 /// This file only makes sense when not building size-minimized. It's not header-only.
 
-#if defined(USE_LD)
+#include "vgl_config.hpp"
+
+#if defined(VGL_USE_LD)
 
 #include "vgl_string_view.hpp"
 


### PR DESCRIPTION
Add `VGL_ENABLE_VERTEX_NORMAL_PACKING` toggle for packing normals into shorts, resulting in unaligned vertex data. Since this causes performance issues on some platforms (tested: Mali G610), it is default off.
Do not use `ivec3` for anything unless the former feature is enabled.
Add error checking for normalizing integer vectors.
Add description for configuration options into `vgl_config.hpp`.
Use VGL_USE_LD as opposed to USE_LD everywhere.
Add some missing constepr descriptions to suitable places.
Try to include `vgl_config.hpp` in absolutely every conceivable header path.
Fix minor doxygen issues.